### PR TITLE
Bump version to 0.0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ You can then retrieve your contract address in your tests scripts to run test on
 Import:
 javascript
 ```
-const { addressBook } = require('hardhat')
+const { addressBook, network } = require('hardhat')
 ```
 typescript
 ```
-import { addressBook } from 'hardhat'
+import { addressBook, network } from 'hardhat'
 ```
 
 Usage:
@@ -133,9 +133,24 @@ addressBook.retrieveContract(contractName: string, deployedNetwork: string)
 
 Example:
 ```
-await addressBook.saveContract('MockERC20', mockERC20.address, 'ethereum', deployer.address)
+await addressBook.saveContract('MockERC20', mockERC20.address, network.name, deployer.address)
 
-await addressBook.retrieveContract('MockERC20', 'ethereum')
+await addressBook.retrieveContract('MockERC20', network.name)
+```
+
+
+Retrieve Admin Proxy contract address deployed by @openzeppelin/hardhat-upgrades library
+
+Usage:
+```
+
+addressBook.retrieveOZAdminProxyContract(chainId: number)
+```
+
+Example:
+```
+
+await addressBook.retrieveOZAdminProxyContract(network.config.chainId)
 ```
 
 <details>
@@ -162,7 +177,7 @@ await addressBook.retrieveContract('MockERC20', 'ethereum')
     - Offer to create test scripts
     - Offer to create Foundry/Forge test contracts
 - Tool to log all contracts deploy on each chain (1 unique contractName/chain + full log) and retrieve them (not tested yet)
-    - hre.addressBook.{ saveContract, retrieveContract }
+    - hre.addressBook.{ saveContract, retrieveContract, retrieveOZAdminProxyContract }
 - Flatten your contracts (All contracts, or specific contracts) save in contractsFlatten/
 - Write some test on the package using mocha
 </details>

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ npm link hardhat-awesome-cli
 - Polygon - Mainnet (chainId 137)
 - Polygon - Mumbai (chainId 80001)
 - Binance Smart Chain - Mainnet (chainId 56)
-- Binance Smart Chain - Tesnet (chainId 97)
+- Binance Smart Chain - Testnet (chainId 97)
 - Optimism - Mainnet (chainId 10)
 - Optimism - Testnet Kovan (chainId 69)
 - Avalanche - Mainnet (chainId 43114)
@@ -126,7 +126,7 @@ import { addressBook, network } from 'hardhat'
 
 Usage:
 ```
-addressBook.saveContract(contractName: string, contractAddress: string, deployedNetwork: string, deployedBy: string)
+addressBook.saveContract(contractName: string, contractAddress: string, deployedNetwork: string, deployedBy: string, blockHah?: string, blockNumber?: number)
 
 addressBook.retrieveContract(contractName: string, deployedNetwork: string)
 ```
@@ -138,6 +138,37 @@ await addressBook.saveContract('MockERC20', mockERC20.address, network.name, dep
 await addressBook.retrieveContract('MockERC20', network.name)
 ```
 
+Return:
+```
+address: string
+```
+
+Retrieve a deployed contract object
+
+Usage:
+```
+
+addressBook.retrieveContractObject(contractName: string, deployedNetwork: string)
+```
+
+Example:
+```
+
+await addressBook.retrieveContractObject('MockERC20', network.name)
+```
+
+Return:
+```
+{
+    name: string
+    address: string
+    network: string
+    deployer: string
+    deploymentDate: Date
+    blockHah?: string
+    blockNumber?: number
+}
+```
 
 Retrieve Admin Proxy contract address deployed by @openzeppelin/hardhat-upgrades library
 
@@ -153,6 +184,40 @@ Example:
 await addressBook.retrieveOZAdminProxyContract(network.config.chainId)
 ```
 
+Return:
+```
+address: string
+```
+
+Retrieve all contracts deployed for a network name
+
+Usage:
+```
+
+addressBook.retrieveContractHistory(deployedNetwork: string)
+```
+
+Example:
+```
+
+await addressBook.retrieveContractHistory(network.name)
+```
+
+Return:
+```
+[
+    {
+        name: string
+        address: string
+        network: string
+        deployer: string
+        deploymentDate: Date
+        blockHah?: string
+        blockNumber?: number
+    }
+]
+```
+
 <details>
     <summary>## 💪 Done</summary>
 - Run test on all or single test file (from all your file in test/)
@@ -166,7 +231,7 @@ await addressBook.retrieveOZAdminProxyContract(network.config.chainId)
     - Add ".env.hardhat-awesome-cli" to .gitignore amd .npmignore (create .gitignore if do detected)
     - See all config for activated chain
     - Create Github test workflows
-    - Create Foundry settings, remmapping and test utilities
+    - Create Foundry settings, remapping and test utilities
 - More settings
     - Exclude files from, tests scripts, and contracts selection (useful for config and share helper file)
     - Add/remove other hardhat plugins (In npm/yarn and in hardhat.config)
@@ -177,7 +242,7 @@ await addressBook.retrieveOZAdminProxyContract(network.config.chainId)
     - Offer to create test scripts
     - Offer to create Foundry/Forge test contracts
 - Tool to log all contracts deploy on each chain (1 unique contractName/chain + full log) and retrieve them (not tested yet)
-    - hre.addressBook.{ saveContract, retrieveContract, retrieveOZAdminProxyContract }
+    - hre.addressBook.{ saveContract, retrieveContract, retrieveContractObject, retrieveOZAdminProxyContract, retrieveContractHistory }
 - Flatten your contracts (All contracts, or specific contracts) save in contractsFlatten/
 - Write some test on the package using mocha
 </details>
@@ -187,7 +252,7 @@ await addressBook.retrieveOZAdminProxyContract(network.config.chainId)
 - Deployment contract generator
 - Make 'Run coverage tests' available only if the task is exported by hardhat
 - More Settings:
-    - Handle directory for file exeption
+    - Handle directory for file exception
     - Setup slack API or email report to receive a copy of test result and contracts list deployed
     - Create a custom command
 - Improve all the tests, to test transfer, mint, burn (all basic ERC20, ERC721, ERC1155 functions)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-awesome-cli",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Hardhat made awesome with a flexible CLI to help run test, deploy and more.",
   "repository": "https://github.com/marc-aurele-besner/hardhat-awesome-cli.git",
   "author": "Marc-Aurele Besner <82244926+marc-aurele-besner@users.noreply.github.com>",

--- a/src/AwesomeAddressBook.ts
+++ b/src/AwesomeAddressBook.ts
@@ -101,4 +101,24 @@ export class AwesomeAddressBook {
         }
         return returnContractAddress
     }
+
+    public retrieveOZAdminProxyContract(chainId: number) {
+        let returnContractAddress = ''
+        let ozFileName = `unknown-${chainId}`
+        if (chainId === 1)
+            ozFileName = 'mainnet'
+        else if (chainId === 3)
+            ozFileName = 'ropsten'
+        else if (chainId === 4)
+            ozFileName = 'rinkeby'
+        else if (chainId === 5)
+            ozFileName = 'goerli'
+        else if (chainId === 42)
+            ozFileName = 'kovan'
+        if(fs.existsSync(`.openzeppelin/${ozFileName}.json`)) {
+            const ozFileRawdata: any = fs.readFileSync(`.openzeppelin/${ozFileName}.json`)
+            returnContractAddress = JSON.parse(ozFileRawdata).admin.address
+        }
+        return returnContractAddress
+    }
 }

--- a/src/AwesomeAddressBook.ts
+++ b/src/AwesomeAddressBook.ts
@@ -6,52 +6,38 @@ interface IAddressDetails {
     network: string
     deployer: string
     deploymentDate: Date
+    blockHah?: string
+    blockNumber?: number
 }
 
 export class AwesomeAddressBook {
-    public saveContract(contractName: string, contractAddress: string, deployedNetwork: string, deployedBy: string) {
+    public saveContract(contractName: string, contractAddress: string, deployedNetwork: string, deployedBy: string, blockHah?: string, blockNumber?: number) {
         const contractsAddressDeployedFile = 'contractsAddressDeployed.json'
         const contractsAddressDeployedHistoryFile = 'contractsAddressDeployedHistory.json'
+        const contractToAdd: IAddressDetails = {
+            name: contractName,
+            address: contractAddress,
+            network: deployedNetwork,
+            deployer: deployedBy,
+            deploymentDate: new Date(),
+            blockHah: blockHah || '',
+            blockNumber: blockNumber || 0
+        }
         let contractsAddressDeployed = []
         let contractsAddressDeployedHistory = []
-        let addressModify = false
 
         // Add or edit contract address if deploy on same network
         if (fs.existsSync(contractsAddressDeployedFile)) {
             const rawdata: any = fs.readFileSync(contractsAddressDeployedFile)
             contractsAddressDeployed = JSON.parse(rawdata)
             if (contractsAddressDeployed !== undefined && contractsAddressDeployed.length > 0) {
-                contractsAddressDeployed
-                    .filter((c: IAddressDetails) => c.name === contractName && c.network === deployedNetwork)
-                    .map((c: IAddressDetails) => {
-                        addressModify = true
-                        return {
-                            name: c.name,
-                            address: contractAddress,
-                            network: deployedNetwork,
-                            deployer: deployedBy,
-                            deploymentDate: new Date().toISOString()
-                        }
-                    })
-            }
-            if (!addressModify) {
-                contractsAddressDeployed.push({
-                    name: contractName,
-                    address: contractAddress,
-                    network: deployedNetwork,
-                    deployer: deployedBy,
-                    deploymentDate: new Date().toISOString()
-                })
+                contractsAddressDeployed = contractsAddressDeployed
+                    .filter((c: IAddressDetails) => c.name !== contractName && c.network !== deployedNetwork)
+                contractsAddressDeployed.push(contractToAdd)
             }
             fs.unlinkSync(contractsAddressDeployedFile)
         } else {
-            contractsAddressDeployed.push({
-                name: contractName,
-                address: contractAddress,
-                network: deployedNetwork,
-                deployer: deployedBy,
-                deploymentDate: new Date().toISOString()
-            })
+            contractsAddressDeployed.push(contractToAdd)
         }
         try {
             fs.writeFileSync(contractsAddressDeployedFile, JSON.stringify(contractsAddressDeployed, null, 2))
@@ -63,22 +49,10 @@ export class AwesomeAddressBook {
         if (fs.existsSync(contractsAddressDeployedHistoryFile)) {
             const rawdata: any = fs.readFileSync(contractsAddressDeployedHistoryFile)
             contractsAddressDeployedHistory = JSON.parse(rawdata)
-            contractsAddressDeployedHistory.push({
-                name: contractName,
-                address: contractAddress,
-                network: deployedNetwork,
-                deployer: deployedBy,
-                deploymentDate: new Date().toISOString()
-            })
+            contractsAddressDeployedHistory.push(contractToAdd)
             fs.unlinkSync(contractsAddressDeployedHistoryFile)
         } else {
-            contractsAddressDeployedHistory.push({
-                name: contractName,
-                address: contractAddress,
-                network: deployedNetwork,
-                deployer: deployedBy,
-                deploymentDate: new Date().toISOString()
-            })
+            contractsAddressDeployedHistory.push(contractToAdd)
         }
         try {
             fs.writeFileSync(contractsAddressDeployedHistoryFile, JSON.stringify(contractsAddressDeployedHistory, null, 2))
@@ -89,14 +63,26 @@ export class AwesomeAddressBook {
 
     public retrieveContract(contractName: string, deployedNetwork: string) {
         const contractsAddressDeployedFile = 'contractsAddressDeployed.json'
-        let contractsAddressDeployed = []
         let returnContractAddress = ''
         if (fs.existsSync(contractsAddressDeployedFile)) {
             const rawdata: any = fs.readFileSync(contractsAddressDeployedFile)
-            contractsAddressDeployed = JSON.parse(rawdata)
+            const contractsAddressDeployed: IAddressDetails[] = JSON.parse(rawdata)
             if (contractsAddressDeployed !== undefined && contractsAddressDeployed.length > 0) {
                 returnContractAddress = contractsAddressDeployed.filter((c: IAddressDetails) => c.name === contractName && c.network === deployedNetwork)[0]
                     .address
+            }
+        }
+        return returnContractAddress
+    }
+
+    public retrieveContractObject(contractName: string, deployedNetwork: string) {
+        const contractsAddressDeployedFile = 'contractsAddressDeployed.json'
+        let returnContractAddress = {}
+        if (fs.existsSync(contractsAddressDeployedFile)) {
+            const rawdata: any = fs.readFileSync(contractsAddressDeployedFile)
+            const contractsAddressDeployed: IAddressDetails[] = JSON.parse(rawdata)
+            if (contractsAddressDeployed !== undefined && contractsAddressDeployed.length > 0) {
+                returnContractAddress = contractsAddressDeployed.filter((c: IAddressDetails) => c.name === contractName && c.network === deployedNetwork)[0]
             }
         }
         return returnContractAddress
@@ -118,6 +104,23 @@ export class AwesomeAddressBook {
         if(fs.existsSync(`.openzeppelin/${ozFileName}.json`)) {
             const ozFileRawdata: any = fs.readFileSync(`.openzeppelin/${ozFileName}.json`)
             returnContractAddress = JSON.parse(ozFileRawdata).admin.address
+        }
+        return returnContractAddress
+    }
+
+    public retrieveContractHistory(deployedNetwork: string) {
+        const contractsAddressDeployedFile = 'contractsAddressDeployedHistory.json'
+        let returnContractAddress: IAddressDetails[] = []
+        if (fs.existsSync(contractsAddressDeployedFile)) {
+            const rawdata: any = fs.readFileSync(contractsAddressDeployedFile)
+            const contractsAddressDeployedHistory: IAddressDetails[] = JSON.parse(rawdata)
+            if (contractsAddressDeployedHistory !== undefined && contractsAddressDeployedHistory.length > 0) {
+                contractsAddressDeployedHistory
+                    .filter((c: IAddressDetails) => c.network === deployedNetwork)
+                    .forEach((c: IAddressDetails) => {
+                        returnContractAddress.push(c)
+                    })
+            }
         }
         return returnContractAddress
     }

--- a/src/AwesomeAddressBook.ts
+++ b/src/AwesomeAddressBook.ts
@@ -31,8 +31,7 @@ export class AwesomeAddressBook {
             const rawdata: any = fs.readFileSync(contractsAddressDeployedFile)
             contractsAddressDeployed = JSON.parse(rawdata)
             if (contractsAddressDeployed !== undefined && contractsAddressDeployed.length > 0) {
-                contractsAddressDeployed = contractsAddressDeployed
-                    .filter((c: IAddressDetails) => c.name !== contractName && c.network !== deployedNetwork)
+                contractsAddressDeployed = contractsAddressDeployed.filter((c: IAddressDetails) => c.name !== contractName && c.network !== deployedNetwork)
                 contractsAddressDeployed.push(contractToAdd)
             }
             fs.unlinkSync(contractsAddressDeployedFile)
@@ -91,17 +90,12 @@ export class AwesomeAddressBook {
     public retrieveOZAdminProxyContract(chainId: number) {
         let returnContractAddress = ''
         let ozFileName = `unknown-${chainId}`
-        if (chainId === 1)
-            ozFileName = 'mainnet'
-        else if (chainId === 3)
-            ozFileName = 'ropsten'
-        else if (chainId === 4)
-            ozFileName = 'rinkeby'
-        else if (chainId === 5)
-            ozFileName = 'goerli'
-        else if (chainId === 42)
-            ozFileName = 'kovan'
-        if(fs.existsSync(`.openzeppelin/${ozFileName}.json`)) {
+        if (chainId === 1) ozFileName = 'mainnet'
+        else if (chainId === 3) ozFileName = 'ropsten'
+        else if (chainId === 4) ozFileName = 'rinkeby'
+        else if (chainId === 5) ozFileName = 'goerli'
+        else if (chainId === 42) ozFileName = 'kovan'
+        if (fs.existsSync(`.openzeppelin/${ozFileName}.json`)) {
             const ozFileRawdata: any = fs.readFileSync(`.openzeppelin/${ozFileName}.json`)
             returnContractAddress = JSON.parse(ozFileRawdata).admin.address
         }
@@ -110,7 +104,7 @@ export class AwesomeAddressBook {
 
     public retrieveContractHistory(deployedNetwork: string) {
         const contractsAddressDeployedFile = 'contractsAddressDeployedHistory.json'
-        let returnContractAddress: IAddressDetails[] = []
+        const returnContractAddress: IAddressDetails[] = []
         if (fs.existsSync(contractsAddressDeployedFile)) {
             const rawdata: any = fs.readFileSync(contractsAddressDeployedFile)
             const contractsAddressDeployedHistory: IAddressDetails[] = JSON.parse(rawdata)


### PR DESCRIPTION
## Notable changes:
- Fix issue of addressBook.saveContract that was not overwriting contract with the same name and network name
- Add blockHash and blockNumber as optional arguments for addressBook.saveContract
- Add addressBook.retrieveContractObject to retrieve the full details of a contract deployed
- Add addressBook.retrieveContractHistory to retrieve all contracts deployed under the same network (return object array)
- 