### PR TITLE
feat: browse directories recursively in the files selectors

### DIFF
--- a/src/buildFilesList.ts
+++ b/src/buildFilesList.ts
@@ -22,181 +22,123 @@ export const buildActivatedChainList = async () => {
     return chainList
 }
 
-export const buildAllTestsList = async () => {
+const formatFileName = (file: string, isTest: boolean) => {
+    let fileName = file.replace(/\.[^/.]+$/, '')
+    if (isTest) fileName = fileName.replace(/\.test/, ' - Test')
+    const words = fileName.split(' ')
+    for (let i = 0; i < words.length; i++) {
+        if (words[i].length > 0) words[i] = words[i][0].toUpperCase() + words[i].substring(1)
+    }
+    return words.join(' ')
+}
+
+/**
+ * List the direct content of `rootDirectory/subPath`.
+ *
+ * Directories are returned with a trailing `/` on both their display name and
+ * their file path, and are flagged with the `directory` type so the selectors
+ * can open a new selection inside of them instead of treating them as a file.
+ * Directories are listed first, then files, both in alphabetical order.
+ *
+ * `filePath` is always relative to `rootDirectory`, so a nested file is
+ * returned as `subDirectory/myFile.ts` and can be passed to a command as is.
+ */
+export const buildDirectoryFilesList = (rootDirectory: string, subPath: string = '', isTest: boolean = false) => {
+    const filesList: IFileList[] = []
+    const directoriesList: IFileList[] = []
+    const currentDirectory = rootDirectory + (subPath ? '/' + subPath : '')
+    if (!fs.existsSync(currentDirectory)) return filesList
+    const files = fs.readdirSync(currentDirectory).sort((a, b) => a.localeCompare(b))
+    files.forEach((file) => {
+        const stat = fs.lstatSync(currentDirectory + '/' + file)
+        if (stat.isDirectory()) {
+            directoriesList.push({
+                name: file + '/',
+                type: 'directory',
+                filePath: (subPath ? subPath + '/' : '') + file + '/'
+            })
+        } else {
+            filesList.push({
+                name: formatFileName(file, isTest),
+                type: 'file',
+                filePath: (subPath ? subPath + '/' : '') + file
+            })
+        }
+    })
+    return [...directoriesList, ...filesList]
+}
+
+/**
+ * Recursively list every file found under `rootDirectory`, directories excluded.
+ * Used where a flat list of all selectable files is needed (excluded files settings).
+ */
+export const buildDirectoryFilesListRecursive = (
+    rootDirectory: string,
+    subPath: string = '',
+    isTest: boolean = false
+) => {
+    const filesList: IFileList[] = []
+    buildDirectoryFilesList(rootDirectory, subPath, isTest).forEach((file: IFileList) => {
+        if (file.type === 'directory')
+            filesList.push(...buildDirectoryFilesListRecursive(rootDirectory, file.filePath.slice(0, -1), isTest))
+        else filesList.push(file)
+    })
+    return filesList
+}
+
+export const buildAllTestsList = async (subPath: string = '') => {
     const testList: IFileList[] = []
     if (fs.existsSync('test')) {
-        testList.push({
-            name: 'All tests',
-            type: 'all',
-            filePath: ''
-        })
-        const files = fs.readdirSync('test')
-        files.map((file) => {
-            let fileName
-            if (fs.lstatSync('test/' + file).isFile()) {
-                fileName = file.replace(/\.[^/.]+$/, '').replace(/\.test/, ' - Test')
-            } else if (fs.lstatSync('test/' + file).isDirectory()) {
-                fileName = file + '/'
-                file = file + '/'
-            } else {
-                fileName = file
-            }
-            const words = fileName.split(' ')
-            for (let i = 0; i < words.length; i++) {
-                words[i] = words[i][0].toUpperCase() + words[i].substr(1)
-            }
-            fileName = words.join(' ')
+        if (!subPath)
             testList.push({
-                name: fileName,
-                type: 'file',
-                filePath: file
+                name: 'All tests',
+                type: 'all',
+                filePath: ''
             })
-        })
+        testList.push(...buildDirectoryFilesList('test', subPath, true))
     }
     return testList
 }
 
-export const buildAllScriptsList = async () => {
-    const scriptsList: IFileList[] = []
-    if (fs.existsSync('scripts')) {
-        const files = fs.readdirSync('scripts')
-        files.map((file) => {
-            let fileName
-            if (fs.lstatSync('scripts/' + file).isFile()) {
-                fileName = file.replace(/\.[^/.]+$/, '').replace(/\.test/, ' - Test')
-            } else if (fs.lstatSync('scripts/' + file).isDirectory()) {
-                fileName = file + '/'
-                file = file + '/'
-            } else {
-                fileName = file
-            }
-            const words = fileName.split(' ')
-            for (let i = 0; i < words.length; i++) {
-                words[i] = words[i][0].toUpperCase() + words[i].substr(1)
-            }
-            fileName = words.join(' ')
-            scriptsList.push({
-                name: fileName,
-                type: 'file',
-                filePath: file
-            })
-        })
-    }
-    return scriptsList
+export const buildAllScriptsList = async (subPath: string = '') => {
+    return buildDirectoryFilesList('scripts', subPath)
 }
 
-export const buildAllContractsList = async () => {
-    const scontractsList: IFileList[] = []
-    if (fs.existsSync('contracts')) {
-        const files = fs.readdirSync('contracts')
-        files.map((file) => {
-            let fileName
-            if (fs.lstatSync('contracts/' + file).isFile()) {
-                fileName = file.replace(/\.[^/.]+$/, '')
-            } else if (fs.lstatSync('contracts/' + file).isDirectory()) {
-                fileName = file + '/'
-                file = file + '/'
-            } else {
-                fileName = file
-            }
-            const words = fileName.split(' ')
-            for (let i = 0; i < words.length; i++) {
-                words[i] = words[i][0].toUpperCase() + words[i].substr(1)
-            }
-            fileName = words.join(' ')
-            scontractsList.push({
-                name: fileName,
-                type: 'file',
-                filePath: file
-            })
-        })
-    }
-    return scontractsList
+export const buildAllContractsList = async (subPath: string = '') => {
+    return buildDirectoryFilesList('contracts', subPath)
 }
 
-export const buildAllForgeTestsList = async () => {
+export const buildAllForgeTestsList = async (subPath: string = '') => {
     const testList: IFileList[] = []
-    if (fs.existsSync('test')) {
-        testList.push({
-            name: 'All tests',
-            type: 'all',
-            filePath: ''
-        })
-        const files = fs.readdirSync('contracts/test')
-        files.map((file) => {
-            let fileName
-            if (fs.lstatSync('contracts/test/' + file).isFile()) {
-                fileName = file.replace(/\.[^/.]+$/, '').replace(/\.test/, ' - Test')
-            } else if (fs.lstatSync('contracts/test/' + file).isDirectory()) {
-                fileName = file + '/'
-            } else {
-                fileName = file
-            }
-            const words = fileName.split(' ')
-            for (let i = 0; i < words.length; i++) {
-                words[i] = words[i][0].toUpperCase() + words[i].substr(1)
-            }
-            fileName = words.join(' ')
+    if (fs.existsSync('contracts/test')) {
+        if (!subPath)
             testList.push({
-                name: fileName,
-                type: 'file',
-                filePath: file
+                name: 'All tests',
+                type: 'all',
+                filePath: ''
             })
-        })
+        testList.push(...buildDirectoryFilesList('contracts/test', subPath, true))
     }
     return testList
 }
 
-export const buildTestsList = async () => {
-    let allTestList: IFileList[] = await buildAllTestsList()
-    let excludedFiles: IExcludedFiles[] = await buildExcludedFile()
-    const buildFilePath: string[] = []
-    if (excludedFiles && excludedFiles.length > 0) {
-        excludedFiles = excludedFiles.filter((test: IExcludedFiles) => test.directory === 'test')
-        if (excludedFiles && excludedFiles.length > 0) {
-            excludedFiles.map((file: IExcludedFiles) => {
-                buildFilePath.push(file.filePath)
-            })
-            allTestList = allTestList.filter((script: IFileList) => {
-                return !buildFilePath.includes(script.filePath)
-            })
-            return allTestList
-        } else return allTestList
-    } else return allTestList
+const filterExcludedFiles = (allFiles: IFileList[], excludedFiles: IExcludedFiles[], directory: string) => {
+    if (!excludedFiles || excludedFiles.length === 0) return allFiles
+    const excludedFilePath = excludedFiles
+        .filter((file: IExcludedFiles) => file.directory === directory)
+        .map((file: IExcludedFiles) => file.filePath)
+    if (excludedFilePath.length === 0) return allFiles
+    return allFiles.filter((file: IFileList) => !excludedFilePath.includes(file.filePath))
 }
 
-export const buildScriptsList = async () => {
-    let allScriptList: IFileList[] = await buildAllScriptsList()
-    let excludedFiles: IExcludedFiles[] = await buildExcludedFile()
-    const buildFilePath: string[] = []
-    if (excludedFiles && excludedFiles.length > 0) {
-        excludedFiles = excludedFiles.filter((test: any) => test.directory === 'scripts')
-        if (excludedFiles && excludedFiles.length > 0) {
-            excludedFiles.map((file: any) => {
-                buildFilePath.push(file.filePath)
-            })
-            allScriptList = allScriptList.filter((script: IFileList) => {
-                return !buildFilePath.includes(script.filePath)
-            })
-            return allScriptList
-        } else return allScriptList
-    } else return allScriptList
+export const buildTestsList = async (subPath: string = '') => {
+    return filterExcludedFiles(await buildAllTestsList(subPath), await buildExcludedFile(), 'test')
 }
 
-export const buildContractsList = async () => {
-    let allContractsList: IFileList[] = await buildAllContractsList()
-    let excludedFiles: IExcludedFiles[] = await buildExcludedFile()
-    const buildFilePath: string[] = []
-    if (excludedFiles !== undefined && excludedFiles.length > 0) {
-        excludedFiles = excludedFiles.filter((test: any) => test.directory === 'contracts')
-        if (excludedFiles !== undefined && excludedFiles.length > 0) {
-            excludedFiles.map((file: any) => {
-                buildFilePath.push(file.filePath)
-            })
-            allContractsList = allContractsList.filter((script: IFileList) => {
-                return !buildFilePath.includes(script.filePath)
-            })
-            return allContractsList
-        } else return allContractsList
-    } else return allContractsList
+export const buildScriptsList = async (subPath: string = '') => {
+    return filterExcludedFiles(await buildAllScriptsList(subPath), await buildExcludedFile(), 'scripts')
+}
+
+export const buildContractsList = async (subPath: string = '') => {
+    return filterExcludedFiles(await buildAllContractsList(subPath), await buildExcludedFile(), 'contracts')
 }

--- a/src/serveInquirer.ts
+++ b/src/serveInquirer.ts
@@ -5,11 +5,9 @@ import writeToEnv, { getEnvValue } from './buildEnv.ts'
 import { addExcludedFiles, buildExcludedFile, removeExcludedFiles } from './buildExcludedFile.ts'
 import {
     buildActivatedChainList,
-    buildAllContractsList,
     buildAllForgeTestsList,
-    buildAllScriptsList,
-    buildAllTestsList,
     buildContractsList,
+    buildDirectoryFilesListRecursive,
     buildScriptsList,
     buildTestsList
 } from './buildFilesList.ts'
@@ -102,228 +100,161 @@ const serveNetworkSelector = async (
     if (command) await runCommand(command, firstCommand, commandFlags, true)
 }
 
-const serveTestSelector = async (env: any, command: string, firstCommand: string) => {
-    const testFilesObject = await buildTestsList()
-    let testFilesList: string[] = []
-    if (testFilesObject !== undefined && testFilesObject.length > 0) {
-        testFilesList = testFilesObject.map((file: IFileList) => {
-            return file.name
-        })
-        if (testFilesList.length > 0) {
-            await inquirer
-                .prompt([
-                    {
-                        type: 'list',
-                        name: 'test',
-                        message: 'Select a test',
-                        choices: testFilesList
-                    }
-                ])
-                .then(async (testSelected: { test: string }) => {
-                    testFilesObject.forEach((file: IFileList) => {
-                        if (file.name === testSelected.test) {
-                            if (file.type === 'file') command = command + ' test/' + file.filePath
-                        }
-                    })
-                    if (firstCommand) command = 'npx hardhat test ' + command
-                    await serveNetworkSelector(env, command, firstCommand, '', '', false)
-                    await sleep(5000)
-                })
+const goBackChoice = '.. (go back)'
+
+type TFileSelection = IFileList | 'back' | undefined
+
+/**
+ * Prompt for a file, opening a new selection every time a directory is selected.
+ *
+ * Directories are listed with a trailing `/` and are browsed recursively until a
+ * file (or an entry like `All tests`) is picked. Nested selections offer a
+ * `.. (go back)` choice to return to the parent directory.
+ *
+ * Resolves to the selected file, its `filePath` being relative to the root
+ * directory of the list (eg. `subDirectory/myTest.test.ts`), or `undefined`
+ * when there is nothing to select.
+ */
+const serveFileListSelector = async (
+    message: string,
+    buildList: (subPath: string) => Promise<IFileList[]>,
+    subPath: string = ''
+): Promise<TFileSelection> => {
+    for (;;) {
+        const filesObject = await buildList(subPath)
+        const filesList: string[] = filesObject ? filesObject.map((file: IFileList) => file.name) : []
+        if (filesList.length === 0) {
+            if (!subPath) return undefined
+            console.log('\x1b[33m%s\x1b[0m', 'No file found in ' + subPath + ', going back')
+            return 'back'
         }
+        if (subPath) filesList.push(goBackChoice)
+        const fileSelected: { file: string } = await inquirer.prompt([
+            {
+                type: 'list',
+                name: 'file',
+                message: subPath ? message + ' (' + subPath + ')' : message,
+                choices: filesList
+            }
+        ])
+        if (fileSelected.file === goBackChoice) return 'back'
+        const selected = filesObject.find((file: IFileList) => file.name === fileSelected.file)
+        if (!selected) return undefined
+        if (selected.type !== 'directory') return selected
+        const selectedInDirectory = await serveFileListSelector(message, buildList, selected.filePath.slice(0, -1))
+        if (selectedInDirectory !== 'back') return selectedInDirectory
     }
 }
 
+const serveTestSelector = async (env: any, command: string, firstCommand: string) => {
+    const testSelected = await serveFileListSelector('Select a test', buildTestsList)
+    if (!testSelected || testSelected === 'back') return
+    if (testSelected.type === 'file') command = command + ' test/' + testSelected.filePath
+    if (firstCommand) command = 'npx hardhat test ' + command
+    await serveNetworkSelector(env, command, firstCommand, '', '', false)
+    await sleep(5000)
+}
+
 const serveScriptSelector = async (env: any, ServeTestSelector: any) => {
-    const scriptFilesObject = await buildScriptsList()
-    const scriptFilesList: string[] = []
-    if (scriptFilesObject) {
-        scriptFilesObject.map((file: IFileList) => {
-            scriptFilesList.push(file.name)
-        })
-        if (scriptFilesObject.length > 0) {
-            await inquirer
-                .prompt([
-                    {
-                        type: 'list',
-                        name: 'script',
-                        message: 'Select a script',
-                        choices: scriptFilesList
-                    }
-                ])
-                .then(async (scriptSelected: { script: string }) => {
-                    let command = 'npx hardhat run'
-                    scriptFilesObject.forEach((file: IFileList) => {
-                        if (file.name === scriptSelected.script) {
-                            if (file.type === 'file') command = command + ' scripts/' + file.filePath
-                        }
-                    })
-                    if (ServeTestSelector) await ServeTestSelector(env, '', command)
-                    else {
-                        await serveNetworkSelector(env, command, '', '', '', false)
-                        await sleep(5000)
-                    }
-                })
-        }
+    const scriptSelected = await serveFileListSelector('Select a script', buildScriptsList)
+    if (!scriptSelected || scriptSelected === 'back') return
+    let command = 'npx hardhat run'
+    if (scriptSelected.type === 'file') command = command + ' scripts/' + scriptSelected.filePath
+    if (ServeTestSelector) await ServeTestSelector(env, '', command)
+    else {
+        await serveNetworkSelector(env, command, '', '', '', false)
+        await sleep(5000)
     }
 }
 
 const serveFlattenContractsSelector = async (env: any, command: string) => {
-    const contractsFilesObject = await buildContractsList()
-    const contractsFilesList: string[] = ['Flatten all contracts']
     const addressBookConfig = getAddressBookConfig(env.userConfig)
     let renameLicenseIdentifier = false
-    if (contractsFilesObject) {
-        contractsFilesObject.map((file: IFileList) => {
-            contractsFilesList.push(file.name)
+    const contractSelected = await serveFileListSelector('Select a contract to flatten', async (subPath: string) => {
+        const contractsFilesObject = await buildContractsList(subPath)
+        if (subPath) return contractsFilesObject
+        return [{ name: 'Flatten all contracts', type: 'all', filePath: '' }, ...contractsFilesObject]
+    })
+    if (!contractSelected || contractSelected === 'back') return
+    let contractFlattenName: string = addressBookConfig.contractsFlattenPrefix + 'All.sol'
+    if (contractSelected.type === 'file') {
+        command = command + ' contracts/' + contractSelected.filePath
+        contractFlattenName = addressBookConfig.contractsFlattenPrefix + contractSelected.filePath.replace(/\//g, '-')
+    }
+    await inquirer
+        .prompt([
+            {
+                type: 'confirm',
+                name: 'renameLicenseIdentifier',
+                message: 'Rename SPDX-License-Identifier'
+            }
+        ])
+        .then((contractsSelected: { renameLicenseIdentifier: boolean }) => {
+            renameLicenseIdentifier = contractsSelected.renameLicenseIdentifier
         })
-        if (contractsFilesList.length > 0) {
-            let contractFlattenName: string = ''
-            await inquirer
-                .prompt([
-                    {
-                        type: 'list',
-                        name: 'flatten',
-                        message: 'Select a contract to flatten',
-                        choices: contractsFilesList
-                    },
-                    {
-                        type: 'confirm',
-                        name: 'renameLicenseIdentifier',
-                        message: 'Rename SPDX-License-Identifier'
-                    }
-                ])
-                .then(async (contractsSelected: { flatten: string; renameLicenseIdentifier: boolean }) => {
-                    renameLicenseIdentifier = contractsSelected.renameLicenseIdentifier
-                    if (!fs.existsSync(addressBookConfig.contractsFlattenPath))
-                        fs.mkdirSync(addressBookConfig.contractsFlattenPath)
-                    if (contractsSelected.flatten !== 'Flatten all contracts') {
-                        contractsFilesObject.forEach((file: IFileList) => {
-                            if (file.name === contractsSelected.flatten) {
-                                if (file.type === 'file') {
-                                    command = command + ' contracts/' + file.filePath
-                                    contractFlattenName = addressBookConfig.contractsFlattenPrefix + file.filePath
-                                }
-                            }
-                        })
-                    } else contractFlattenName = addressBookConfig.contractsFlattenPrefix + 'All.sol'
-                })
-            if (command) {
-                await runCommand(
-                    command,
-                    '',
-                    ' > ' + addressBookConfig.contractsFlattenPath + '/' + contractFlattenName,
-                    renameLicenseIdentifier ? false : true
+    if (!fs.existsSync(addressBookConfig.contractsFlattenPath)) fs.mkdirSync(addressBookConfig.contractsFlattenPath)
+    if (command) {
+        await runCommand(
+            command,
+            '',
+            ' > ' + addressBookConfig.contractsFlattenPath + '/' + contractFlattenName,
+            renameLicenseIdentifier ? false : true
+        )
+        await sleep(3000)
+        if (renameLicenseIdentifier) {
+            while (
+                fs.readFileSync(addressBookConfig.contractsFlattenPath + '/' + contractFlattenName, 'utf8').length === 0
+            ) {
+                await sleep(1000)
+            }
+            if (
+                fs.readFileSync(addressBookConfig.contractsFlattenPath + '/' + contractFlattenName, 'utf8').length > 0
+            ) {
+                let fileContent = fs.readFileSync(
+                    addressBookConfig.contractsFlattenPath + '/' + contractFlattenName,
+                    'utf8'
                 )
-                await sleep(3000)
-                if (renameLicenseIdentifier) {
-                    while (
-                        fs.readFileSync(addressBookConfig.contractsFlattenPath + '/' + contractFlattenName, 'utf8')
-                            .length === 0
-                    ) {
-                        await sleep(1000)
-                    }
-                    if (
-                        fs.readFileSync(addressBookConfig.contractsFlattenPath + '/' + contractFlattenName, 'utf8')
-                            .length > 0
-                    ) {
-                        let fileContent = fs.readFileSync(
-                            addressBookConfig.contractsFlattenPath + '/' + contractFlattenName,
-                            'utf8'
-                        )
-                        if (fileContent.includes('SPDX-License-Identifier')) {
-                            fileContent = fileContent.replace(
-                                'SPDX-License-Identifier',
-                                'SPDX-License-DISABLED-Identifier'
-                            )
-                            fs.writeFileSync(
-                                addressBookConfig.contractsFlattenPath + '/' + contractFlattenName,
-                                fileContent
-                            )
-                        } else
-                            console.log(
-                                'SPDX-License-Identifier not found in ' + contractFlattenName + ' file, skipping rename'
-                            )
-                        if (fileContent.includes('pragma solidity')) {
-                            fileContent = fileContent.replace('pragma solidity', '// pragma solidity')
-                            fs.writeFileSync(
-                                addressBookConfig.contractsFlattenPath + '/' + contractFlattenName,
-                                fileContent
-                            )
-                        } else
-                            console.log(
-                                'pragma solidity not found in ' + contractFlattenName + ' file, skipping rename'
-                            )
-                    }
-                }
+                if (fileContent.includes('SPDX-License-Identifier')) {
+                    fileContent = fileContent.replace('SPDX-License-Identifier', 'SPDX-License-DISABLED-Identifier')
+                    fs.writeFileSync(addressBookConfig.contractsFlattenPath + '/' + contractFlattenName, fileContent)
+                } else
+                    console.log(
+                        'SPDX-License-Identifier not found in ' + contractFlattenName + ' file, skipping rename'
+                    )
+                if (fileContent.includes('pragma solidity')) {
+                    fileContent = fileContent.replace('pragma solidity', '// pragma solidity')
+                    fs.writeFileSync(addressBookConfig.contractsFlattenPath + '/' + contractFlattenName, fileContent)
+                } else console.log('pragma solidity not found in ' + contractFlattenName + ' file, skipping rename')
             }
         }
     }
 }
 
 const serveFunctionListSelector = async (env: any) => {
-    const contractsFilesObject = await buildContractsList()
-    const contractsFilesList: string[] = []
-    if (contractsFilesObject) {
-        contractsFilesObject.map((file: IFileList) => contractsFilesList.push(file.name))
-        if (contractsFilesList.length > 0)
-            await inquirer
-                .prompt([
-                    {
-                        type: 'list',
-                        name: 'contractName',
-                        message: 'Select a contract to list all functions',
-                        choices: contractsFilesList
-                    }
-                ])
-                .then(async (contractsSelected: { contractName: string }) => {
-                    const functions = await listAllFunctionSelectors(env, contractsSelected.contractName)
-                    console.log(
-                        'Contract: ',
-                        '\x1b[32m',
-                        contractsSelected.contractName,
-                        '\x1b[0m',
-                        'has ',
-                        '\x1b[32m',
-                        functions.length,
-                        '\x1b[0m',
-                        'public and external functions, ordered by selector'
-                    )
-                    console.table(functions)
-                    await sleep(5000)
-                })
-    }
+    const contractSelected = await serveFileListSelector('Select a contract to list all functions', buildContractsList)
+    if (!contractSelected || contractSelected === 'back') return
+    const functions = await listAllFunctionSelectors(env, contractSelected.name)
+    console.log(
+        'Contract: ',
+        '\x1b[32m',
+        contractSelected.name,
+        '\x1b[0m',
+        'has ',
+        '\x1b[32m',
+        functions.length,
+        '\x1b[0m',
+        'public and external functions, ordered by selector'
+    )
+    console.table(functions)
+    await sleep(5000)
 }
 
 const serveFoundryTestSelector = async (env: any, command: string) => {
-    const testFilesObject = await buildAllForgeTestsList()
-    let testFilesList: string[] = []
-    if (testFilesObject) {
-        testFilesList = testFilesObject.map((file: IFileList) => {
-            return file.name
-        })
-        if (testFilesList.length > 0) {
-            await inquirer
-                .prompt([
-                    {
-                        type: 'list',
-                        name: 'test',
-                        message: 'Select a forge test',
-                        choices: testFilesList
-                    }
-                ])
-                .then(async (testSelected: { test: string }) => {
-                    testFilesObject.forEach((file: IFileList) => {
-                        if (file.name === testSelected.test) {
-                            if (file.type === 'file') {
-                                command = command + ' --match-path contracts/test/' + file.filePath
-                            }
-                        }
-                    })
-                    await runCommand(command, '', '', true)
-                    await sleep(5000)
-                })
-        }
-    }
+    const testSelected = await serveFileListSelector('Select a forge test', buildAllForgeTestsList)
+    if (!testSelected || testSelected === 'back') return
+    if (testSelected.type === 'file') command = command + ' --match-path contracts/test/' + testSelected.filePath
+    await runCommand(command, '', '', true)
+    await sleep(5000)
 }
 
 const serveEnvBuilder = async (env: any, chainSelected: string) => {
@@ -504,9 +435,9 @@ const serveExcludeFileSelector = async (option: string) => {
     let excludedFiles: IExcludedFiles[] = await buildExcludedFile()
     const allFilesSelection: string[] = []
     let allExcludedSelection: string[] = []
-    if (option === 'test') allFiles = await buildAllTestsList()
-    else if (option === 'scripts') allFiles = await buildAllScriptsList()
-    else if (option === 'contracts') allFiles = await buildAllContractsList()
+    if (option === 'test') allFiles = buildDirectoryFilesListRecursive('test', '', true)
+    else if (option === 'scripts') allFiles = buildDirectoryFilesListRecursive('scripts')
+    else if (option === 'contracts') allFiles = buildDirectoryFilesListRecursive('contracts')
     if (allFiles && allFiles.length > 0) {
         if (allFiles.filter((test: IFileList) => test.type === 'file').length > 0) {
             allFiles
@@ -538,7 +469,7 @@ const serveExcludeFileSelector = async (option: string) => {
             allFiles.map(async (file: IFileList) => {
                 if (activateFilesSelected.allFiles.includes(file.filePath))
                     await addExcludedFiles(option, file.name, file.filePath)
-                else await removeExcludedFiles(option, file.name)
+                else await removeExcludedFiles(option, file.filePath)
             })
             console.log('\x1b[32m%s\x1b[0m', 'Settings updated!')
         })

--- a/test/buildFilesList.test.ts
+++ b/test/buildFilesList.test.ts
@@ -1,0 +1,82 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import {
+    buildAllContractsList,
+    buildAllTestsList,
+    buildDirectoryFilesList,
+    buildDirectoryFilesListRecursive
+} from '../src/buildFilesList.ts'
+import type { IFileList } from '../src/types.ts'
+
+describe('buildFilesList', function () {
+    const initialCwd = process.cwd()
+    let fixtureDirectory: string
+
+    before(function () {
+        fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-'))
+        fs.mkdirSync(path.join(fixtureDirectory, 'test/nested/deeper'), { recursive: true })
+        fs.mkdirSync(path.join(fixtureDirectory, 'contracts/interfaces'), { recursive: true })
+        fs.writeFileSync(path.join(fixtureDirectory, 'test/Token.test.ts'), '')
+        fs.writeFileSync(path.join(fixtureDirectory, 'test/nested/Nested.test.ts'), '')
+        fs.writeFileSync(path.join(fixtureDirectory, 'test/nested/deeper/Deeper.test.ts'), '')
+        fs.writeFileSync(path.join(fixtureDirectory, 'contracts/Token.sol'), '')
+        fs.writeFileSync(path.join(fixtureDirectory, 'contracts/interfaces/IToken.sol'), '')
+        process.chdir(fixtureDirectory)
+    })
+
+    after(function () {
+        process.chdir(initialCwd)
+        fs.rmSync(fixtureDirectory, { recursive: true, force: true })
+    })
+
+    it('Mark directories with a trailing / and flag them as directory', async function () {
+        const testList = await buildAllTestsList()
+        const nested = testList.find((file: IFileList) => file.type === 'directory')
+        expect(nested).to.not.equal(undefined)
+        expect((nested as IFileList).name).to.equal('nested/')
+        expect((nested as IFileList).filePath).to.equal('nested/')
+    })
+
+    it('List directories before files', async function () {
+        const contractsList = await buildAllContractsList()
+        expect(contractsList.map((file: IFileList) => file.type)).to.deep.equal(['directory', 'file'])
+    })
+
+    it('Only add the All tests entry at the root of the test directory', async function () {
+        expect((await buildAllTestsList()).filter((file: IFileList) => file.type === 'all').length).to.equal(1)
+        expect((await buildAllTestsList('nested')).filter((file: IFileList) => file.type === 'all').length).to.equal(0)
+    })
+
+    it('List the content of a sub directory with a path relative to the root directory', async function () {
+        const nestedList = await buildAllTestsList('nested')
+        expect(nestedList.map((file: IFileList) => file.filePath)).to.deep.equal([
+            'nested/deeper/',
+            'nested/Nested.test.ts'
+        ])
+        const deeperList = await buildAllTestsList('nested/deeper')
+        expect(deeperList.map((file: IFileList) => file.filePath)).to.deep.equal(['nested/deeper/Deeper.test.ts'])
+    })
+
+    it('Format file names and keep the extension out of the display name', async function () {
+        const testList = await buildAllTestsList()
+        const file = testList.find((entry: IFileList) => entry.filePath === 'Token.test.ts')
+        expect((file as IFileList).name).to.equal('Token - Test')
+    })
+
+    it('Return an empty list for a directory that does not exist', function () {
+        expect(buildDirectoryFilesList('doesNotExist')).to.deep.equal([])
+    })
+
+    it('Recursively list every file, directories excluded', function () {
+        const allFiles = buildDirectoryFilesListRecursive('test', '', true)
+        expect(allFiles.map((file: IFileList) => file.filePath).sort()).to.deep.equal([
+            'Token.test.ts',
+            'nested/Nested.test.ts',
+            'nested/deeper/Deeper.test.ts'
+        ])
+        expect(allFiles.every((file: IFileList) => file.type === 'file')).to.equal(true)
+    })
+})


### PR DESCRIPTION
Closes #34

## Problem

In the tests, scripts and contracts selectors, directories were listed like any other file. Selecting one built a command pointing at a directory (`npx hardhat test test/nested/`) instead of a file, and there was no way to reach a nested file at all.

## Solution

Directories are now marked with a trailing `/`, flagged with a `directory` type, and open a **new selection with their own content** when selected — recursively, until a file is picked.

```
? Select a test
❯ All tests
  nested/
  Token - Test

? Select a test (nested)
❯ deeper/
  Nested - Test
  .. (go back)

? Select a test (nested/deeper)
❯ Deeper - Test
  .. (go back)

=> npx hardhat test test/nested/deeper/Deeper.test.ts
```

Nested prompts show the current sub directory in their message and offer a `.. (go back)` choice to return to the parent directory.

## Changes

- New `serveFileListSelector` helper in `src/serveInquirer.ts`, shared by the tests, scripts, contracts (flatten), function list and forge tests selectors. The five selectors were each re-implementing the same prompt block.
- The four list builders shared the same duplicated `readdir`/format logic, they now delegate to a single `buildDirectoryFilesList` helper. `filePath` is returned relative to the root directory (eg. `subDirectory/myTest.test.ts`) so it can be passed to a command as is. Directories are listed before files, both alphabetically.
- `All tests` is only added at the root of the test directory, not inside sub directories.

Fixes found along the way, needed to make nested files usable end to end:

- Excluded files settings now list every file recursively — nested files could not be excluded before.
- Excluded files removal was given the display name instead of the file path, so it never matched the stored entry.
- Flatten output name replaces `/` with `-` to stay a valid file name (`hac-sub/Foo.sol` would have failed to write).
- The forge tests list existence check tested `test`, but the function reads `contracts/test`.

## Testing

- New `test/buildFilesList.test.ts` covering directory marking, ordering, sub directory listing, name formatting, missing directories and recursive listing. `npm test` — 23 passing.
- `npm run lint` clean.
- Manually drove `serveFileListSelector` against a fixture tree with a scripted prompt mock to verify recursion, back navigation and the resulting command (output above).
- `npm run build` reports the same pre-existing errors as `main` (the repo does not currently typecheck clean).

## Note

Two pre-existing runtime bugs unrelated to this PR block the interactive menu from even starting and are worth their own issue: `src/serveInquirer.ts` imports `./mockContracts.ts` but the file is `./mockContracts/index.ts`, and `src/packageInstaller.ts:185` uses `require` in an ES module.