### PR TITLE
feat: create all mock contracts and their tests at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ npm link hardhat-awesome-cli
           </details>
 
 -   Create Mock contracts + (Deployment scripts, tests scripts and Foundry(Forge) test contracts (Missing test for MockProxyAdmin and MockTransparentUpgradeableProxy))
+    -   All mock contracts (create every mock contract below, with their deployment and test scripts, at the same time)
     -   MockERC20
     -   MockERC721
     -   MockERC1155

--- a/src/buildMockContracts.ts
+++ b/src/buildMockContracts.ts
@@ -1,123 +1,126 @@
 import fs from 'fs'
 import path from 'path'
+import { fileURLToPath } from 'url'
 
-import MockContractsList from './mockContracts.ts'
+import MockContractsList from './mockContracts/index.ts'
 import detectPackage from './packageInstaller.ts'
 import type { IMockContractsList } from './types.ts'
 import { sleep } from './utils.ts'
 
+/**
+ * Locate the packaged `mockContracts` directory holding the Solidity, deployment
+ * script and test templates.
+ *
+ * Only the source tree carries those templates: `package.json` ships both `src/`
+ * and `dist/`, but `tsc` merely compiles `.ts` files, it never copies the `.sol`
+ * assets into `dist/`. So `dist/src/mockContracts` exists yet is incomplete,
+ * which is why the candidates below are validated against a marker file instead
+ * of a plain directory check.
+ *
+ * Hardhat 2 resolved this from `require.main.filename`; `require` does not exist
+ * in an ES module, so we resolve relative to this file instead.
+ */
+const resolveMockContractsPath = (): string | undefined => {
+    const currentDir = path.dirname(fileURLToPath(import.meta.url))
+    const candidates = [
+        path.join(currentDir, 'mockContracts'), // running from src/
+        path.join(currentDir, '../../src/mockContracts') // running from dist/src/
+    ]
+    return candidates.find((candidate) => fs.existsSync(path.join(candidate, 'MockERC20.sol')))
+}
+
 const buildMockContract = async (contractName: string) => {
-    if (require && require.main) {
-        const packageRootPath = path.join(
-            path.dirname(require.main.filename),
-            '../../../hardhat-awesome-cli/src/mockContracts'
-        )
-        if (fs.existsSync(packageRootPath)) {
-            if (fs.existsSync('contracts')) {
-                if (MockContractsList) {
-                    const contractToMock: IMockContractsList[] = MockContractsList.filter(
-                        (contract) => contract.name === contractName
-                    )
-                    if (contractToMock) {
-                        if (fs.existsSync('contracts/' + contractName + '.sol'))
-                            console.log('\x1b[33m%s\x1b[0m', 'Mock contract already exists')
-                        else {
-                            if (fs.existsSync('contracts/' + contractName + '.sol'))
-                                console.log('\x1b[33m%s\x1b[0m', "Can't locate the mock contract")
-                            else {
-                                console.log('\x1b[32m%s\x1b[0m', 'Creating ', contractName, ' in contracts/')
-                                fs.copyFileSync(
-                                    packageRootPath + '/' + contractName + '.sol',
-                                    'contracts/' + contractName + '.sol'
-                                )
-                            }
+    const packageRootPath = resolveMockContractsPath()
+    if (packageRootPath) {
+        if (fs.existsSync('contracts')) {
+            if (MockContractsList) {
+                const contractToMock: IMockContractsList[] = MockContractsList.filter(
+                    (contract) => contract.name === contractName
+                )
+                if (contractToMock) {
+                    if (fs.existsSync('contracts/' + contractName + '.sol'))
+                        console.log('\x1b[33m%s\x1b[0m', 'Mock contract already exists')
+                    else {
+                        console.log('\x1b[32m%s\x1b[0m', 'Creating ', contractName, ' in contracts/')
+                        fs.copyFileSync(
+                            packageRootPath + '/' + contractName + '.sol',
+                            'contracts/' + contractName + '.sol'
+                        )
+                    }
+                    if (contractToMock[0].dependencies && contractToMock[0].dependencies.length > 0) {
+                        for (const dependency of contractToMock[0].dependencies) {
+                            await detectPackage(dependency, true, false, false)
                         }
-                        if (contractToMock[0].dependencies && contractToMock[0].dependencies.length > 0) {
-                            contractToMock[0].dependencies.forEach(async (dependency: string) => {
-                                await detectPackage(dependency, true, false, false)
-                            })
-                            await sleep(3000)
-                        }
+                        await sleep(3000)
                     }
                 }
-            } else console.log('\x1b[33m%s\x1b[0m', 'Error creating mock contract')
-        }
+            }
+        } else console.log('\x1b[33m%s\x1b[0m', 'Error creating mock contract')
     }
 }
 
 export const buildMockDeploymentScriptOrTest = async (contractName: string, type: string) => {
-    if (require && require.main) {
-        const packageRootPath = path.join(
-            path.dirname(require.main.filename),
-            '../../../hardhat-awesome-cli/src/mockContracts'
-        )
-        if (fs.existsSync(packageRootPath)) {
-            if (fs.existsSync('contracts')) {
-                if (MockContractsList) {
-                    let deploymentScriptOrTestPath: string = ''
-                    let finalPath: string = ''
-                    let scriptOrTestDir: string = ''
-                    const contractToMock: IMockContractsList[] = MockContractsList.filter(
-                        (contract) => contract.name === contractName
-                    )
-                    if (contractToMock && type === 'deployment') {
-                        scriptOrTestDir = 'scripts'
-                        if (fs.existsSync('hardhat.config.js')) {
-                            if (contractToMock[0].deploymentScriptJs !== undefined)
-                                deploymentScriptOrTestPath = contractToMock[0].deploymentScriptJs
-                        } else if (fs.existsSync('hardhat.config.ts')) {
-                            if (contractToMock[0].deploymentScriptTs !== undefined)
-                                deploymentScriptOrTestPath = contractToMock[0].deploymentScriptTs
-                            else if (contractToMock[0].deploymentScriptJs !== undefined)
-                                deploymentScriptOrTestPath = contractToMock[0].deploymentScriptJs
-                        }
-                        finalPath = deploymentScriptOrTestPath
+    const packageRootPath = resolveMockContractsPath()
+    if (packageRootPath) {
+        if (fs.existsSync('contracts')) {
+            if (MockContractsList) {
+                let deploymentScriptOrTestPath: string = ''
+                let finalPath: string = ''
+                let scriptOrTestDir: string = ''
+                const contractToMock: IMockContractsList[] = MockContractsList.filter(
+                    (contract) => contract.name === contractName
+                )
+                if (contractToMock && type === 'deployment') {
+                    scriptOrTestDir = 'scripts'
+                    if (fs.existsSync('hardhat.config.js')) {
+                        if (contractToMock[0].deploymentScriptJs !== undefined)
+                            deploymentScriptOrTestPath = contractToMock[0].deploymentScriptJs
+                    } else if (fs.existsSync('hardhat.config.ts')) {
+                        if (contractToMock[0].deploymentScriptTs !== undefined)
+                            deploymentScriptOrTestPath = contractToMock[0].deploymentScriptTs
+                        else if (contractToMock[0].deploymentScriptJs !== undefined)
+                            deploymentScriptOrTestPath = contractToMock[0].deploymentScriptJs
                     }
-                    if (contractToMock && type === 'test') {
-                        scriptOrTestDir = 'test'
-                        if (fs.existsSync('hardhat.config.js')) {
-                            if (contractToMock[0].testScriptJs !== undefined)
-                                deploymentScriptOrTestPath = contractToMock[0].testScriptJs
-                        } else if (fs.existsSync('hardhat.config.ts')) {
-                            if (contractToMock[0].testScriptTs !== undefined)
-                                deploymentScriptOrTestPath = contractToMock[0].testScriptTs
-                            else if (contractToMock[0].testScriptJs !== undefined)
-                                deploymentScriptOrTestPath = contractToMock[0].testScriptJs
-                        }
-                        finalPath = deploymentScriptOrTestPath
+                    finalPath = deploymentScriptOrTestPath
+                }
+                if (contractToMock && type === 'test') {
+                    scriptOrTestDir = 'test'
+                    if (fs.existsSync('hardhat.config.js')) {
+                        if (contractToMock[0].testScriptJs !== undefined)
+                            deploymentScriptOrTestPath = contractToMock[0].testScriptJs
+                    } else if (fs.existsSync('hardhat.config.ts')) {
+                        if (contractToMock[0].testScriptTs !== undefined)
+                            deploymentScriptOrTestPath = contractToMock[0].testScriptTs
+                        else if (contractToMock[0].testScriptJs !== undefined)
+                            deploymentScriptOrTestPath = contractToMock[0].testScriptJs
                     }
-                    if (contractToMock && type === 'testForge') {
-                        scriptOrTestDir = 'contracts/test'
-                        if (contractToMock[0]?.testContractFoundry !== undefined)
-                            deploymentScriptOrTestPath = contractToMock[0].testContractFoundry
-                        finalPath = deploymentScriptOrTestPath.replace('testForge/', 'contracts/test/')
-                    }
-                    if (contractToMock && deploymentScriptOrTestPath && finalPath) {
-                        if (fs.existsSync(finalPath))
-                            console.log(
-                                '\x1b[33m%s\x1b[0m',
-                                'The ' + type + ' in ' + scriptOrTestDir + '/ already exists'
-                            )
-                        else {
-                            if (fs.existsSync(deploymentScriptOrTestPath))
-                                console.log('\x1b[33m%s\x1b[0m', "Can't locate the " + type + ' ' + scriptOrTestDir)
-                            else {
-                                console.log(
-                                    '\x1b[32m%s\x1b[0m',
-                                    'Creating ' + type + ' for ',
-                                    contractName,
-                                    ' in ' + scriptOrTestDir + '/'
-                                )
-                                if (!fs.existsSync(scriptOrTestDir + '/')) fs.mkdirSync(scriptOrTestDir + '/')
-                                const rawData: any = fs.readFileSync(packageRootPath + '/' + deploymentScriptOrTestPath)
-                                await sleep(500)
-                                fs.writeFileSync(finalPath, rawData)
-                            }
-                        }
+                    finalPath = deploymentScriptOrTestPath
+                }
+                if (contractToMock && type === 'testForge') {
+                    scriptOrTestDir = 'contracts/test'
+                    if (contractToMock[0]?.testContractFoundry !== undefined)
+                        deploymentScriptOrTestPath = contractToMock[0].testContractFoundry
+                    finalPath = deploymentScriptOrTestPath.replace('testForge/', 'contracts/test/')
+                }
+                if (contractToMock && deploymentScriptOrTestPath && finalPath) {
+                    if (fs.existsSync(finalPath))
+                        console.log('\x1b[33m%s\x1b[0m', 'The ' + type + ' in ' + scriptOrTestDir + '/ already exists')
+                    else {
+                        console.log(
+                            '\x1b[32m%s\x1b[0m',
+                            'Creating ' + type + ' for ',
+                            contractName,
+                            ' in ' + scriptOrTestDir + '/'
+                        )
+                        if (!fs.existsSync(scriptOrTestDir + '/'))
+                            fs.mkdirSync(scriptOrTestDir + '/', { recursive: true })
+                        const rawData: any = fs.readFileSync(packageRootPath + '/' + deploymentScriptOrTestPath)
+                        await sleep(500)
+                        fs.writeFileSync(finalPath, rawData)
                     }
                 }
-            } else console.log('\x1b[33m%s\x1b[0m', 'Error creating ' + type + ' script')
-        }
+            }
+        } else console.log('\x1b[33m%s\x1b[0m', 'Error creating ' + type + ' script')
     }
 }
 

--- a/src/packageInstaller.ts
+++ b/src/packageInstaller.ts
@@ -182,39 +182,42 @@ const detectPackage = async (
     uninstall: boolean,
     addRemoveInHardhatConfig: boolean
 ) => {
-    if (require && require.main) {
-        const nodeModulesPath = path.join(path.dirname(require.main.filename), '../../../')
-        if (fs.existsSync(nodeModulesPath + packageName)) {
-            if (uninstall) {
-                console.log('\x1b[34m%s\x1b[0m', 'Uninstalling package: ', '\x1b[97m\x1b[0m', packageName)
-                if (fs.existsSync('package-lock.json')) {
-                    if (addRemoveInHardhatConfig) await importPackageHardhatConfigFile(packageName, false, true)
-                    await runCommand('npm remove ' + packageName, '', '', false)
-                    await sleep(5000)
-                } else if (fs.existsSync('yarn-lock.json')) {
-                    if (addRemoveInHardhatConfig) await importPackageHardhatConfigFile(packageName, false, true)
-                    await runCommand('yarn remove ' + packageName, '', '', false)
-                    await sleep(5000)
-                }
+    // Hardhat 2 walked up from `require.main.filename` to reach the consuming
+    // project's `node_modules`. `require` does not exist in an ES module, and the
+    // rest of this CLI already treats the current working directory as the
+    // Hardhat project root (`contracts/`, `hardhat.config.ts`, `package-lock.json`),
+    // so resolve `node_modules` from there instead.
+    const nodeModulesPath = path.join(process.cwd(), 'node_modules')
+    if (fs.existsSync(path.join(nodeModulesPath, packageName))) {
+        if (uninstall) {
+            console.log('\x1b[34m%s\x1b[0m', 'Uninstalling package: ', '\x1b[97m\x1b[0m', packageName)
+            if (fs.existsSync('package-lock.json')) {
+                if (addRemoveInHardhatConfig) await importPackageHardhatConfigFile(packageName, false, true)
+                await runCommand('npm remove ' + packageName, '', '', false)
+                await sleep(5000)
+            } else if (fs.existsSync('yarn-lock.json')) {
+                if (addRemoveInHardhatConfig) await importPackageHardhatConfigFile(packageName, false, true)
+                await runCommand('yarn remove ' + packageName, '', '', false)
+                await sleep(5000)
             }
-            return true
-        } else {
-            if (install) {
-                console.log('\x1b[34m%s\x1b[0m', 'Installing package: ', '\x1b[97m\x1b[0m', packageName)
-                if (fs.existsSync('package-lock.json')) {
-                    console.log('\x1b[33m%s\x1b[0m', 'Detected package-lock.json, installing with npm')
-                    if (addRemoveInHardhatConfig) await importPackageHardhatConfigFile(packageName, true, false)
-                    await runCommand('npm install ' + packageName, '', ' --save-dev', false)
-                    await sleep(5000)
-                } else if (fs.existsSync('yarn-lock.json')) {
-                    console.log('\x1b[33m%s\x1b[0m', 'Detected yarn-lock.json, installing with yarn')
-                    if (addRemoveInHardhatConfig) await importPackageHardhatConfigFile(packageName, true, false)
-                    await runCommand('yarn add ' + packageName, '', ' -D', false)
-                    await sleep(5000)
-                }
-            }
-            return false
         }
+        return true
+    } else {
+        if (install) {
+            console.log('\x1b[34m%s\x1b[0m', 'Installing package: ', '\x1b[97m\x1b[0m', packageName)
+            if (fs.existsSync('package-lock.json')) {
+                console.log('\x1b[33m%s\x1b[0m', 'Detected package-lock.json, installing with npm')
+                if (addRemoveInHardhatConfig) await importPackageHardhatConfigFile(packageName, true, false)
+                await runCommand('npm install ' + packageName, '', ' --save-dev', false)
+                await sleep(5000)
+            } else if (fs.existsSync('yarn-lock.json')) {
+                console.log('\x1b[33m%s\x1b[0m', 'Detected yarn-lock.json, installing with yarn')
+                if (addRemoveInHardhatConfig) await importPackageHardhatConfigFile(packageName, true, false)
+                await runCommand('yarn add ' + packageName, '', ' -D', false)
+                await sleep(5000)
+            }
+        }
+        return false
     }
 }
 

--- a/src/serveInquirer.ts
+++ b/src/serveInquirer.ts
@@ -27,7 +27,7 @@ import {
     DefaultHardhatPluginsList,
     getAddressBookConfig
 } from './config.ts'
-import MockContractsList from './mockContracts.ts'
+import MockContractsList from './mockContracts/index.ts'
 import detectPackage from './packageInstaller.ts'
 import {
     IChain,
@@ -49,6 +49,10 @@ import {
     runCommand,
     sleep
 } from './utils.ts'
+
+// Entry added on top of the mock contract selection to create every mock contract
+// (and their deployment/test scripts) in a single pass.
+const ALL_MOCK_CONTRACTS = 'All mock contracts'
 
 const serveNetworkSelector = async (
     env: any,
@@ -619,9 +623,9 @@ const serveMockContractCreatorSelector = async () => {
             return file.name
         })
         let mockContractFirstSelected: string = ''
-        let mockContractToAdd:
+        let mockContractsToAdd:
             | {
-                  mockContract: string
+                  mockContracts: string[]
                   mockDeploymentScript: string
                   mockTestScript: string
                   mockTestContractFoundry: string
@@ -633,46 +637,54 @@ const serveMockContractCreatorSelector = async () => {
                     type: 'list',
                     name: 'mockContract',
                     message: 'Select a mock contract',
-                    choices: mockContractsList
+                    choices: [ALL_MOCK_CONTRACTS, ...mockContractsList]
                 }
             ])
             .then(async (mockContractSelected: { mockContract: string }) => {
                 mockContractFirstSelected = mockContractSelected.mockContract
             })
         if (mockContractFirstSelected) {
-            const mockContractFirstSelectedDetail = MockContractsList.filter(
-                (file: IMockContractsList) => file.name === mockContractFirstSelected
-            )[0]
+            // Selecting `ALL_MOCK_CONTRACTS` applies the answers below to every mock contract at once
+            const mockContractsSelectedDetail: IMockContractsList[] =
+                mockContractFirstSelected === ALL_MOCK_CONTRACTS
+                    ? MockContractsList
+                    : MockContractsList.filter((file: IMockContractsList) => file.name === mockContractFirstSelected)
+            const subject = mockContractsSelectedDetail.length > 1 ? 'these mock contracts' : 'this mock contract'
             const mockContractDetailSelector = []
             if (
-                mockContractFirstSelectedDetail.deploymentScriptJs !== undefined ||
-                mockContractFirstSelectedDetail.deploymentScriptTs !== undefined
+                mockContractsSelectedDetail.some(
+                    (file: IMockContractsList) =>
+                        file.deploymentScriptJs !== undefined || file.deploymentScriptTs !== undefined
+                )
             )
                 mockContractDetailSelector.push({
                     type: 'list',
                     name: 'mockDeploymentScript',
-                    message: 'Create a deployment script for this mock contract',
+                    message: 'Create a deployment script for ' + subject,
                     choices: ['yes', 'no']
                 })
             if (
-                mockContractFirstSelectedDetail.testScriptJs !== undefined ||
-                mockContractFirstSelectedDetail.testScriptTs !== undefined
+                mockContractsSelectedDetail.some(
+                    (file: IMockContractsList) => file.testScriptJs !== undefined || file.testScriptTs !== undefined
+                )
             )
                 mockContractDetailSelector.push({
                     type: 'list',
                     name: 'mockTestScript',
-                    message: 'Create a test script for this mock contract',
+                    message: 'Create a test script for ' + subject,
                     choices: ['yes', 'no']
                 })
             if (
-                mockContractFirstSelectedDetail.testContractFoundry !== undefined &&
+                mockContractsSelectedDetail.some(
+                    (file: IMockContractsList) => file.testContractFoundry !== undefined
+                ) &&
                 fs.existsSync('contracts/test') &&
                 fs.existsSync('foundry.toml')
             )
                 mockContractDetailSelector.push({
                     type: 'list',
                     name: 'mockTestContractFoundry',
-                    message: 'Create a Foundry test contract for this mock contract',
+                    message: 'Create a Foundry test contract for ' + subject,
                     choices: ['yes', 'no']
                 })
             await inquirer
@@ -683,8 +695,8 @@ const serveMockContractCreatorSelector = async () => {
                         mockTestScript: string
                         mockTestContractFoundry: string
                     }) => {
-                        mockContractToAdd = {
-                            mockContract: mockContractFirstSelected,
+                        mockContractsToAdd = {
+                            mockContracts: mockContractsSelectedDetail.map((file: IMockContractsList) => file.name),
                             mockDeploymentScript: mockContractSelected.mockDeploymentScript || 'no',
                             mockTestScript: mockContractSelected.mockTestScript || 'no',
                             mockTestContractFoundry: mockContractSelected.mockTestContractFoundry || 'no'
@@ -692,14 +704,16 @@ const serveMockContractCreatorSelector = async () => {
                     }
                 )
         }
-        if (mockContractToAdd !== undefined) {
-            await buildMockContract(mockContractToAdd.mockContract)
-            if (mockContractToAdd.mockDeploymentScript === 'yes')
-                await buildMockDeploymentScriptOrTest(mockContractToAdd.mockContract, 'deployment')
-            if (mockContractToAdd.mockTestScript === 'yes')
-                await buildMockDeploymentScriptOrTest(mockContractToAdd.mockContract, 'test')
-            if (mockContractToAdd.mockTestContractFoundry === 'yes')
-                await buildMockDeploymentScriptOrTest(mockContractToAdd.mockContract, 'testForge')
+        if (mockContractsToAdd !== undefined) {
+            for (const mockContract of mockContractsToAdd.mockContracts) {
+                await buildMockContract(mockContract)
+                if (mockContractsToAdd.mockDeploymentScript === 'yes')
+                    await buildMockDeploymentScriptOrTest(mockContract, 'deployment')
+                if (mockContractsToAdd.mockTestScript === 'yes')
+                    await buildMockDeploymentScriptOrTest(mockContract, 'test')
+                if (mockContractsToAdd.mockTestContractFoundry === 'yes')
+                    await buildMockDeploymentScriptOrTest(mockContract, 'testForge')
+            }
         }
     }
 }


### PR DESCRIPTION
### Summary

Closes #69 — adds an **All mock contracts** entry on top of the mock contract selection, so a full set of mocks can be scaffolded in a single pass instead of walking the menu eight times.

Picking it applies the deployment script / test script / Foundry test answers to every mock contract. The follow-up questions are offered when *any* selected contract supports that artifact, and their wording adapts to the number of contracts selected. Contracts that don't ship a given artifact are skipped, so mocks without a test script (`MockProxyAdmin`, `MockTransparentUpgradeableProxy`) no longer block the batch.

### Bug found along the way

The feature was completely dead before this PR, so the first commit repairs it:

- The package became an ES module in the Hardhat 3 migration, but `buildMockContracts.ts` and `packageInstaller.ts` still resolved paths via `require.main.filename`. `require` is not defined in an ES module, so **every** mock contract creation threw `ReferenceError: require is not defined` before writing a single file.
- Both files imported `./mockContracts.ts`, a module that never existed (the file is `./mockContracts/index.ts`). This was one of the errors `tsc` already reported.
- Templates are now resolved from `import.meta.url`. Only the source tree carries the `.sol` assets — `tsc` compiles `.ts` and does not copy Solidity files — so `dist/src/mockContracts` exists but is incomplete; candidates are validated against a marker file rather than a plain directory check.
- `detectPackage` now resolves `node_modules` from the working directory, matching how the rest of the CLI already locates the Hardhat project.
- Dependency installs are awaited sequentially; `forEach(async ...)` never awaited, so installs raced each other — which would have been much worse when scaffolding all eight mocks at once.

### Testing

Ran the batch flow against a scratch Hardhat project (`contracts/`, `contracts/test/`, `hardhat.config.ts`, `foundry.toml`):

- 8 contracts, 8 deployment scripts, 6 test scripts and 6 Foundry test contracts created
- re-running is idempotent (28 × "already exists", nothing overwritten)
- single-contract selection verified unchanged
- `npm run lint` clean, `npm test` 23 passing
- `tsc` reports the same 60 pre-existing errors as `main`; the two `TS2307 Cannot find module` errors are fixed and no new error kinds appear

### Follow-up

The same `require.main` ESM breakage still affects `buildWorkflows.ts` and `buildFoundrySetting.ts` (GitHub workflow and Foundry setup creation). Left out of this PR to keep it scoped — happy to open a separate issue.
