### PR TITLE
fix: keep hardhat as default in network selector when not picked in setup (#32)

### DIFF
--- a/src/buildNetworks.ts
+++ b/src/buildNetworks.ts
@@ -185,3 +185,52 @@ export const addCustomChain = async (chainDetails: IChain) => {
         console.log('\x1b[33m%s\x1b[0m', 'Chain with same chainId already exists in your settings activated chain list')
     else await addChain(chainDetails.chainName, chainDetails)
 }
+
+/**
+ * Build the list of chains offered in the network selector from the user's
+ * activated chain list.
+ *
+ * - `noLocalNetwork` filters the `hardhat` entry out (used when editing the
+ *   RPC / accounts for a chain, where the in-memory hardhat network doesn't
+ *   apply).
+ * - When local networks are allowed, `hardhat` is always re-injected as the
+ *   default, even if the user removed it from their activated list. This
+ *   keeps the local dev network visible in later actions (tests, scripts,
+ *   deployments, account balance) even when only mainnet / testnet chains
+ *   were ticked in the setup screen. The selection is returned alongside
+ *   `activatedChainList` so the caller can resolve the chosen name back to
+ *   the matching `IChain` without an extra lookup. See issue #32.
+ * - If the user has no chains at all (fresh project), `hardhat` and
+ *   `localhost` are added as defaults so the selector is never empty.
+ */
+export const buildNetworkSelectorChoices = (
+    activatedChainList: IChain[],
+    noLocalNetwork: boolean
+): { chains: IChain[]; names: string[] } => {
+    const chains: IChain[] = []
+    activatedChainList.forEach((chain: IChain) => {
+        if (noLocalNetwork && chain.chainName === 'hardhat') return
+        chains.push(chain)
+    })
+
+    if (!noLocalNetwork && chains.length === 0) {
+        // Fresh project — neither hardhat nor localhost are activated yet, so
+        // expose both as sensible defaults.
+        const defaultHardhat = DefaultChainList.find((chain: IChain) => chain.chainName === 'hardhat')
+        const defaultLocalhost = DefaultChainList.find((chain: IChain) => chain.chainName === 'localhost')
+        if (defaultHardhat) chains.push(defaultHardhat)
+        if (defaultLocalhost) chains.push(defaultLocalhost)
+    } else if (!noLocalNetwork) {
+        // User already activated some chains but didn't pick the local hardhat
+        // network — re-inject it so it stays available for later actions
+        // (tests, scripts, deployments, account balance). See issue #32.
+        const hasHardhat = chains.some((chain: IChain) => chain.chainName === 'hardhat')
+        if (!hasHardhat) {
+            const defaultHardhat = DefaultChainList.find((chain: IChain) => chain.chainName === 'hardhat')
+            if (defaultHardhat) chains.unshift(defaultHardhat)
+        }
+    }
+
+    const names = chains.map((chain: IChain) => chain.name)
+    return { chains, names }
+}

--- a/src/serveInquirer.ts
+++ b/src/serveInquirer.ts
@@ -17,6 +17,7 @@ import {
     addActivatedChain,
     addCustomChain,
     buildActivatedChainNetworkConfig,
+    buildNetworkSelectorChoices,
     removeActivatedChain
 } from './buildNetworks.ts'
 import buildWorkflows, { buildWorkflowsFromCommand } from './buildWorkflows.ts'
@@ -62,27 +63,11 @@ const serveNetworkSelector = async (
     ServeEnvBuilder: any,
     noLocalNetwork: boolean
 ) => {
-    const ActivatedChainList: IChain[] = await buildActivatedChainList()
-    const BuildFullChainList: IChain[] = DefaultChainList
-    const activatedChainList: string[] = []
-    ActivatedChainList.map((chain: IChain) => {
-        if (noLocalNetwork && chain.chainName !== 'hardhat') activatedChainList.push(chain.name)
-        else if (!noLocalNetwork) activatedChainList.push(chain.name)
-    })
-    if (activatedChainList.length === 0) {
-        const addHardhat = BuildFullChainList.find((basicChain: IChain) => basicChain.chainName === 'hardhat')
-        const addHardhatLocalhost = BuildFullChainList.find(
-            (basicChain: IChain) => basicChain.chainName === 'localhost'
-        )
-        if (addHardhat) {
-            ActivatedChainList.push(addHardhat)
-            activatedChainList.push(addHardhat.name)
-        }
-        if (addHardhatLocalhost) {
-            ActivatedChainList.push(addHardhatLocalhost)
-            activatedChainList.push(addHardhatLocalhost.name)
-        }
-    }
+    const activatedChainListFromFile: IChain[] = await buildActivatedChainList()
+    const { chains: ActivatedChainList, names: activatedChainList } = buildNetworkSelectorChoices(
+        activatedChainListFromFile,
+        noLocalNetwork
+    )
     let commandFlags = ''
     await inquirer
         .prompt([

--- a/test/buildNetworks.test.ts
+++ b/test/buildNetworks.test.ts
@@ -1,0 +1,60 @@
+import { expect } from 'chai'
+
+import { buildNetworkSelectorChoices } from '../src/buildNetworks.ts'
+import { DefaultChainList } from '../src/config.ts'
+import type { IChain } from '../src/types.ts'
+
+const findChain = (chainName: string): IChain => {
+    const chain = DefaultChainList.find((entry: IChain) => entry.chainName === chainName)
+    if (!chain) throw new Error(`Test fixture missing default chain "${chainName}"`)
+    return chain
+}
+
+describe('buildNetworkSelectorChoices', function () {
+    it('Re-injects the hardhat local network when it was not selected in the activated list', function () {
+        const activatedChainList = [findChain('ethereum')]
+        const { chains, names } = buildNetworkSelectorChoices(activatedChainList, false)
+        expect(names).to.include('Hardhat (Temporary instance)')
+        expect(names).to.include('Ethereum - Mainnet')
+        // Bug from issue #32: hardhat used to disappear when the user only
+        // selected mainnet / testnet chains.
+        expect(chains.some((chain: IChain) => chain.chainName === 'hardhat')).to.equal(true)
+    })
+
+    it('Does not duplicate hardhat when it is already in the activated list', function () {
+        const activatedChainList = [findChain('hardhat'), findChain('ethereum')]
+        const { chains } = buildNetworkSelectorChoices(activatedChainList, false)
+        const hardhatCount = chains.filter((chain: IChain) => chain.chainName === 'hardhat').length
+        expect(hardhatCount).to.equal(1)
+    })
+
+    it('Filters hardhat out when noLocalNetwork is set (RPC/accounts editor)', function () {
+        const activatedChainList = [findChain('hardhat'), findChain('ethereum')]
+        const { chains, names } = buildNetworkSelectorChoices(activatedChainList, true)
+        expect(names).to.not.include('Hardhat (Temporary instance)')
+        expect(names).to.include('Ethereum - Mainnet')
+        expect(chains.every((chain: IChain) => chain.chainName !== 'hardhat')).to.equal(true)
+    })
+
+    it('Falls back to hardhat + localhost when no chains are activated at all', function () {
+        const { chains, names } = buildNetworkSelectorChoices([], false)
+        expect(names).to.include('Hardhat (Temporary instance)')
+        expect(names).to.include('Hardhat (Localhost node)')
+        expect(chains.length).to.equal(2)
+    })
+
+    it('Keeps hardhat as the first choice when it has to be re-injected', function () {
+        const activatedChainList = [findChain('ethereum'), findChain('polygon')]
+        const { chains } = buildNetworkSelectorChoices(activatedChainList, false)
+        expect(chains[0].chainName).to.equal('hardhat')
+    })
+
+    it('Preserves the names list aligned with the chains list', function () {
+        const activatedChainList = [findChain('ethereum'), findChain('polygon')]
+        const { chains, names } = buildNetworkSelectorChoices(activatedChainList, false)
+        expect(names.length).to.equal(chains.length)
+        chains.forEach((chain: IChain, index: number) => {
+            expect(names[index]).to.equal(chain.name)
+        })
+    })
+})


### PR DESCRIPTION
Fixes #32.

## Problem

When a user goes to **Setup chains → Add/Remove chains from the chain selection** and ticks only mainnet or testnet chains without selecting the local hardhat network, the hardhat entry used to disappear from every later action that lists networks (run tests, run scripts, flatten contracts, deployments, account balance, ...).

The fallback in `serveNetworkSelector` only re-added hardhat when the activated chain list was completely empty.

## Fix

Move the filtering logic into a new `buildNetworkSelectorChoices` helper in `src/buildNetworks.ts`. When local networks are allowed (the common `noLocalNetwork = false` path), the helper now re-injects the hardhat default whenever it is missing from the user's selection, so the local dev network stays available regardless of what was ticked in the setup screen. The behaviour when `noLocalNetwork = true` (the RPC / accounts editor) is unchanged.

## Tests

Added `test/buildNetworks.test.ts` covering the new helper:
- re-injects hardhat when it is missing from a non-empty activated list
- does not duplicate hardhat when it is already present
- still filters hardhat out for `noLocalNetwork = true`
- falls back to hardhat + localhost when the file has no chains at all
- puts hardhat first when it has to be re-injected
- keeps `names` aligned with `chains`

`npm test` and `npm run lint` both pass.