### PR TITLE
Document the function selector list helper #92

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ npm link hardhat-awesome-cli
 -   Flatten all your contract or a specific contract (offer to rename SPDX-License-Identifier -> SPDX-License-Flatten-Identifier to avoid multiple license identifier issue)
 -   Run Forge test on all or single test contracts if forge setting is detected
 -   Run coverage tests (Available only if solidity-coverage is installed and available as a task)
+-   List function selectors (Print every public and external function of a contract with its 4 bytes selector, ordered by selector)
 -   Setup chains, RPC and accounts
     -   Add/Remove chains from the chain selection
     -   Set RPC Url, private key or mnemonic for all or one chain
@@ -332,6 +333,77 @@ Example:
 await addressBook.cleanContractDeployed('network', 'hardhat', true, true)
 ```
 
+### Function Selector List
+
+List every public and external function of a contract with its 4 bytes function selector (the first 4 bytes of the keccak256 hash of the canonical function signature), ordered by selector. This is what you see in a transaction `data` field or in a revert trace, so it is handy to map an unknown selector back to a function, to check for selector clashes between a proxy and its implementation, or to build a low level `call`.
+
+The contract needs to be compiled first (`npx hardhat compile`), and `hre.ethers` needs to be available (`@nomicfoundation/hardhat-ethers`).
+
+From the CLI, select `List function selectors` in the menu, then pick a contract:
+
+```commandline
+npx hardhat cli
+```
+
+```txt
+Contract:  MockERC20  has  16  public and external functions, ordered by selector
+┌─────────┬──────────────────────────────────┬──────────────┐
+│ (index) │ name                             │ selector     │
+├─────────┼──────────────────────────────────┼──────────────┤
+│ 0       │ 'allowance(address,address)'     │ '0xdd62ed3e' │
+│ 1       │ 'transfer(address,uint256)'      │ '0xa9059cbb' │
+└─────────┴──────────────────────────────────┴──────────────┘
+```
+
+You can also use it in your scripts and tests.
+
+Import:
+
+typescript
+
+```ts
+import { FunctionList } from 'hardhat-awesome-cli/plugin'
+```
+
+javascript
+
+```js
+const { FunctionList } = require('hardhat-awesome-cli/plugin')
+```
+
+Usage:
+
+```js
+
+new FunctionList(hre: HardhatRuntimeEnvironment)
+
+functionList.listSelectors(contractName: string)
+```
+
+Example:
+
+```ts
+import hre from 'hardhat'
+import { FunctionList } from 'hardhat-awesome-cli/plugin'
+
+const functionList = new FunctionList(hre)
+
+const functions = await functionList.listSelectors('MockERC20')
+
+const transfer = functions.find((fn) => fn.name === 'transfer(address,uint256)')
+```
+
+Return (also printed as a table with `console.table`):
+
+```js
+[
+    {
+        name: string // canonical signature, ex: 'transfer(address,uint256)'
+        selector: string // 4 bytes selector, ex: '0xa9059cbb'
+    }
+]
+```
+
 <details>
     <summary>## 💪 Done</summary>
 - Run test on all or single test file (from all your file in test/)
@@ -359,6 +431,7 @@ await addressBook.cleanContractDeployed('network', 'hardhat', true, true)
     - hre.addressBook.{ saveContract, retrieveContract, retrieveContractObject, retrieveOZAdminProxyContract, retrieveContractHistory }
 - Flatten your contracts (All contracts, or specific contracts) save in contractsFlatten/ and offer to rename SPDX-License-Identifier -> SPDX-License-Flatten-Identifier to avoid multiple license identifier issue
 - Write some test on the package using mocha
+- List all public and external function selectors of a contract (from the CLI menu or with the FunctionList helper)
 - Add optional flag to "cli" command to access some functionality
 </details>
 

--- a/src/functionList.ts
+++ b/src/functionList.ts
@@ -1,12 +1,36 @@
 import { listAllFunctionSelectors } from './utils.ts'
 
+/**
+ * Helper exposing the function selector list of a contract, both from the CLI
+ * menu ("List function selectors") and from your own scripts and tests.
+ *
+ * ```ts
+ * import hre from 'hardhat'
+ * import { FunctionList } from 'hardhat-awesome-cli/plugin'
+ *
+ * const functionList = new FunctionList(hre)
+ * const functions = await functionList.listSelectors('MockERC20')
+ * ```
+ */
 export class FunctionList {
     private readonly _env: any
 
+    /**
+     * @param hre Hardhat Runtime Environment (needs `hre.ethers`)
+     */
     constructor(hre: any) {
         this._env = hre
     }
 
+    /**
+     * Print, as a table, every public and external function of `contractName`
+     * with its 4 bytes selector, ordered by selector (ascending).
+     *
+     * The contract needs to be compiled first.
+     *
+     * @param contractName Name of the contract to inspect (e.g. `MockERC20`)
+     * @returns `{ name, selector }` for each function, ordered by selector
+     */
     public async listSelectors(contractName: string) {
         const functions = await listAllFunctionSelectors(this._env, contractName)
         console.log(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,14 +71,31 @@ export const runCommand = async (
     })
 }
 
+/**
+ * List every public and external function of a compiled contract with its
+ * 4 bytes function selector, sorted by selector (ascending).
+ *
+ * Requires `hre.ethers` (`@nomicfoundation/hardhat-ethers`) to be available,
+ * and the contract to be compiled. Both ethers v6 (`fragment.selector`) and
+ * ethers v5 (`ethers.utils.id(signature)`) are supported.
+ *
+ * @param hre Hardhat Runtime Environment
+ * @param contractName Name of the contract to inspect (e.g. `MockERC20`)
+ * @returns `{ name, selector }` for each function, ordered by selector
+ */
 export const listAllFunctionSelectors = async (hre: any, contractName: string) => {
     const factory = await hre.ethers.getContractFactory(contractName)
 
     const functions: FunctionSelector[] = []
-    for (const [name] of Object.entries(factory.interface.functions)) {
+    for (const fragment of factory.interface.fragments) {
+        if (fragment.type !== 'function') continue
+        // `sighash` is the canonical signature (`transfer(address,uint256)`)
+        // in both ethers v5 and v6.
+        const name = fragment.format('sighash')
         functions.push({
             name,
-            selector: hre.ethers.utils.id(name).substring(0, 10)
+            // ethers v6 computes the selector on the fragment, ethers v5 does not.
+            selector: fragment.selector ?? hre.ethers.utils.id(name).substring(0, 10)
         })
     }
     functions.sort((a, b) => {

--- a/test/functionList.test.ts
+++ b/test/functionList.test.ts
@@ -1,0 +1,96 @@
+import { expect } from 'chai'
+
+import { FunctionList } from '../src/functionList'
+import { listAllFunctionSelectors } from '../src/utils'
+
+/**
+ * Minimal stand-in for the object `hre.ethers.getContractFactory()` returns.
+ * Only `interface.fragments` is read by `listAllFunctionSelectors`, so the
+ * tests can describe a contract without compiling one.
+ */
+const buildEnv = (fragments: any[], withEthersV5Utils = false) => ({
+    ethers: {
+        getContractFactory: async () => ({ interface: { fragments } }),
+        utils: withEthersV5Utils
+            ? {
+                  // Only the first 4 bytes are used, the rest is never read.
+                  id: (signature: string) =>
+                      signature === 'transfer(address,uint256)'
+                          ? '0xa9059cbb2ab09eb219583f4a59a5d0623ade346d962bcd4e46b11da047c9049b'
+                          : '0xdd62ed3e90e97b3d417db9c0c7522647811bafca5afc6694f143588d255fdfb4'
+              }
+            : undefined
+    }
+})
+
+const transferFragment = {
+    type: 'function',
+    selector: '0xa9059cbb',
+    format: () => 'transfer(address,uint256)'
+}
+
+const allowanceFragment = {
+    type: 'function',
+    selector: '0xdd62ed3e',
+    format: () => 'allowance(address,address)'
+}
+
+const transferEventFragment = {
+    type: 'event',
+    format: () => 'Transfer(address,address,uint256)'
+}
+
+describe('Integration tests', function () {
+    describe('listAllFunctionSelectors()', function () {
+        it('returns the name and selector of every function', async function () {
+            const functions = await listAllFunctionSelectors(buildEnv([transferFragment]), 'MockERC20')
+
+            expect(functions).to.deep.equal([{ name: 'transfer(address,uint256)', selector: '0xa9059cbb' }])
+        })
+
+        it('orders the functions by selector', async function () {
+            const functions = await listAllFunctionSelectors(
+                buildEnv([allowanceFragment, transferFragment]),
+                'MockERC20'
+            )
+
+            expect(functions.map((fn) => fn.selector)).to.deep.equal(['0xa9059cbb', '0xdd62ed3e'])
+        })
+
+        it('skips fragments that are not functions', async function () {
+            const functions = await listAllFunctionSelectors(
+                buildEnv([transferFragment, transferEventFragment]),
+                'MockERC20'
+            )
+
+            expect(functions).to.have.lengthOf(1)
+        })
+
+        it('falls back on ethers.utils.id() when the fragment has no selector', async function () {
+            const fragments = [
+                { type: 'function', format: () => 'transfer(address,uint256)' },
+                { type: 'function', format: () => 'allowance(address,address)' }
+            ]
+
+            const functions = await listAllFunctionSelectors(buildEnv(fragments, true), 'MockERC20')
+
+            expect(functions).to.deep.equal([
+                { name: 'transfer(address,uint256)', selector: '0xa9059cbb' },
+                { name: 'allowance(address,address)', selector: '0xdd62ed3e' }
+            ])
+        })
+    })
+
+    describe('FunctionList', function () {
+        it('listSelectors() returns the selectors of the contract', async function () {
+            const functionList = new FunctionList(buildEnv([transferFragment, allowanceFragment]))
+
+            const functions = await functionList.listSelectors('MockERC20')
+
+            expect(functions).to.deep.equal([
+                { name: 'transfer(address,uint256)', selector: '0xa9059cbb' },
+                { name: 'allowance(address,address)', selector: '0xdd62ed3e' }
+            ])
+        })
+    })
+})


### PR DESCRIPTION
### Summary

Closes #92.

The function selector list added in #91 was reachable from the CLI menu and exported as `FunctionList`, but never documented — so it was undiscoverable outside of the menu.

**Documentation**
- New `Function Selector List` section under *Helper tools*: what a selector is useful for (decoding a `data` field, checking proxy/implementation selector clashes, building a low-level `call`), the `compile` + `hre.ethers` prerequisites, the CLI output, and the import / usage / return shape of `FunctionList` for scripts and tests.
- Added the feature to the *CLI features* and *Done* lists.
- Mirrored the same information as JSDoc on `FunctionList`, `listSelectors()` and `listAllFunctionSelectors()` so it shows up on editor hover.

**Fix needed to make the docs truthful**
- `listAllFunctionSelectors()` read `interface.functions` and `ethers.utils.id()`, both removed in ethers v6, so listing selectors threw on any Hardhat 3 project. It now iterates `interface.fragments` and uses the selector ethers v6 computes on the fragment, with an `ethers.utils.id()` fallback so ethers v5 projects keep working.

### Test plan

- New `test/functionList.test.ts` covers the return shape, the selector ordering, the filtering of non-function fragments, and both selector sources (v6 fragment selector and v5 `utils.id` fallback), using a stubbed contract factory so no compiled contract is required.
- `npm test` — 34 passing.
- `npm run lint` and `prettier --check` clean.