### PR TITLE
feat: expose composed CLI commands

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,16 +49,21 @@ if (fs.existsSync(addressBookConfig.savePath + addressBookConfig.fileContractsAd
     } catch {}
 }
 
+export const buildCommand = (command: string, firstCommand: string, commandFlags: string) => {
+    let commandToRun = command + commandFlags
+    if (firstCommand) {
+        commandToRun = firstCommand + commandFlags + ' && ' + commandToRun
+    }
+    return commandToRun
+}
+
 export const runCommand = async (
     command: string,
     firstCommand: string,
     commandFlags: string,
     thenExit: boolean = true
 ) => {
-    let commandToRun = command + commandFlags
-    if (firstCommand) {
-        commandToRun = firstCommand + commandFlags + ' && ' + commandToRun
-    }
+    const commandToRun = buildCommand(command, firstCommand, commandFlags)
     console.log('\x1b[33m%s\x1b[0m', 'Command to run: ', '\x1b[97m\x1b[0m', commandToRun)
     console.log(`Please wait...
 `)

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,5 +1,6 @@
 import { assert, expect } from 'chai'
 
+import { buildCommand } from '../src/utils.ts'
 import { usePathsEnvironment } from './helpers'
 
 describe('Integration tests', function () {
@@ -18,5 +19,19 @@ describe('Integration tests', function () {
         it('The path CLI is injected in paths', function () {
             expect((this.env.config.paths as any).cli).to.not.equal(undefined)
         })
+    })
+})
+
+describe('Command builder', function () {
+    it('builds a command with flags', function () {
+        expect(buildCommand('npx hardhat test test/example.ts', '', ' --network sepolia')).to.equal(
+            'npx hardhat test test/example.ts --network sepolia'
+        )
+    })
+
+    it('builds a chained command with flags on both commands', function () {
+        expect(buildCommand('npm run deploy', 'npm install', ' --network sepolia')).to.equal(
+            'npm install --network sepolia && npm run deploy --network sepolia'
+        )
     })
 })


### PR DESCRIPTION
## Summary\n- extract final command composition into exported  helper\n- add coverage for flags and chained commands\n\nCloses #39\n\n## Tests\n- 
> hardhat-awesome-cli@0.1.4 test
> mocha --exit --recursive 'test/**/*.test.ts'



  Integration tests
    AwesomeAddressBook
      ✔ saveContract()
      ✔ saveContract() wit extra arguments
      ✔ 2x saveContract() wit extra arguments
      ✔ 4x saveContract() (2 different contracts twice, replacing 1st entry)
      ✔ saveContract() wit extra arguments, then clean then from log
      ✔ saveContract() wit extra arguments, and extra record, then clean then from log
      ✔ 3x saveContract() wit extra arguments, then clean then from log
      ✔ 3x saveContract() wit extra arguments, then clean then from lo only one
      ✔ retrieveContract()
      ✔ retrieveContractObject()
      ✔ contractsAddressDeployed.json exist
      ✔ contractsAddressDeployedHistory.json exist
      ✔ Delete contractsAddressDeployed.json from previous tests
      ✔ Delete contractsAddressDeployedHistory.json from previous tests

  buildFilesList
    ✔ Mark directories with a trailing / and flag them as directory
    ✔ List directories before files
    ✔ Only add the All tests entry at the root of the test directory
    ✔ List the content of a sub directory with a path relative to the root directory
    ✔ Format file names and keep the extension out of the display name
    ✔ Return an empty list for a directory that does not exist
    ✔ Recursively list every file, directories excluded

  buildNetworkSelectorChoices
    ✔ Re-injects the hardhat local network when it was not selected in the activated list
    ✔ Does not duplicate hardhat when it is already in the activated list
    ✔ Filters hardhat out when noLocalNetwork is set (RPC/accounts editor)
    ✔ Falls back to hardhat + localhost when no chains are activated at all
    ✔ Keeps hardhat as the first choice when it has to be re-injected
    ✔ Preserves the names list aligned with the chains list

  Integration tests
    Hardhat CLI task
      ✔ The task CLI is available
    HardhatConfig extension
      ✔ The path CLI is injected in paths

  Command builder
    ✔ builds a command with flags
    ✔ builds a chained command with flags on both commands

  Integration tests
    listAllFunctionSelectors()
      ✔ returns the name and selector of every function
      ✔ orders the functions by selector
      ✔ skips fragments that are not functions
      ✔ falls back on ethers.utils.id() when the fragment has no selector
    FunctionList
Contract:  [32m MockERC20 [0m has  [32m 2 [0m public and external functions, ordered by selector
┌─────────┬──────────────────────────────┬──────────────┐
│ (index) │ name                         │ selector     │
├─────────┼──────────────────────────────┼──────────────┤
│ 0       │ 'transfer(address,uint256)'  │ '0xa9059cbb' │
│ 1       │ 'allowance(address,address)' │ '0xdd62ed3e' │
└─────────┴──────────────────────────────┴──────────────┘
      ✔ listSelectors() returns the selectors of the contract


  36 passing (172ms)\n- 
> hardhat-awesome-cli@0.1.4 lint
> eslint src test\n- 
> hardhat-awesome-cli@0.1.4 build
> tsc --project tsconfig.prod.json

src/AwesomeAddressBook.ts(3,38): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/buildEnv.ts(3,38): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/buildExcludedFile.ts(3,56): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/buildExcludedFile.ts(4,38): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/buildFilesList.ts(3,35): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/buildFilesList.ts(4,38): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/buildFoundrySetting.ts(4,45): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/buildMockContracts.ts(5,31): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/buildMockContracts.ts(6,27): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/buildMockContracts.ts(8,23): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/buildNetworks.ts(3,29): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/buildNetworks.ts(4,41): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/buildNetworks.ts(5,56): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/buildWorkflows.ts(4,44): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/buildWorkflows.ts(5,27): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/functionList.ts(1,42): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/index.ts(3,27): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/index.ts(22,11): error TS2554: Expected 2 arguments, but got 1.
src/mockContracts/scripts/deploy-Mock-ERC1155.ts(11,80): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-ERC1155Upgradeable.ts(14,17): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-ERC20.ts(11,76): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-ERC20Upgradeable.ts(11,98): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-ERC721.ts(11,78): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-ERC721Upgradeable.ts(14,17): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-Proxy-Admin.ts(11,86): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-Transparent-Upgradeable-Proxy.ts(8,17): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-Transparent-Upgradeable-Proxy.ts(8,47): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-Transparent-Upgradeable-Proxy.ts(9,92): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-Transparent-Upgradeable-Proxy.ts(10,113): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-Transparent-Upgradeable-Proxy.ts(11,114): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-Transparent-Upgradeable-Proxy.ts(21,21): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-Transparent-Upgradeable-Proxy.ts(30,17): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-Transparent-Upgradeable-Proxy.ts(30,47): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-Transparent-Upgradeable-Proxy.ts(31,97): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-Transparent-Upgradeable-Proxy.ts(38,90): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/mockContracts/scripts/deploy-Mock-Transparent-Upgradeable-Proxy.ts(55,17): error TS2339: Property 'name' does not exist on type 'NetworkManager'.
src/packageInstaller.ts(4,35): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/plugin/cli-action.ts(3,22): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/plugin/index.ts(7,42): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/plugin/index.ts(70,29): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/plugin/index.ts(79,38): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/plugin/index.ts(86,42): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/plugin/index.ts(87,36): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/plugin/index.ts(88,30): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/serveInquirer.ts(4,41): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/serveInquirer.ts(5,74): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/serveInquirer.ts(13,8): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/serveInquirer.ts(14,33): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/serveInquirer.ts(15,68): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/serveInquirer.ts(22,8): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/serveInquirer.ts(23,59): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/serveInquirer.ts(30,8): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/serveInquirer.ts(31,31): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/serveInquirer.ts(32,27): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/serveInquirer.ts(40,8): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/serveInquirer.ts(52,8): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
src/utils.ts(5,38): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
test/buildFilesList.test.ts(11,8): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
test/buildNetworks.test.ts(3,45): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
test/buildNetworks.test.ts(4,34): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
test/cli.test.ts(3,30): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
test/hardhat-cli/hardhat.config.ts(5,31): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
test/hardhat-cli/hardhat.config.ts(10,9): error TS2353: Object literal may only specify known properties, and 'cli' does not exist in type 'ProjectPathsUserConfig'. *(fails on pre-existing TypeScript configuration and Hardhat 3 type errors)*