### PR TITLE
feat: integrate foundry-test-utility (closes #88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ npm link hardhat-awesome-cli
 
           </details>
 
+    -   Add foundry-test-utility (npm package for shared Forge mocks & utilities)
+
 -   Create Mock contracts + (Deployment scripts, tests scripts and Foundry(Forge) test contracts (Missing test for MockProxyAdmin and MockTransparentUpgradeableProxy))
     -   All mock contracts (create every mock contract below, with their deployment and test scripts, at the same time)
     -   MockERC20
@@ -157,6 +159,7 @@ In 'More settings' you can also add a custom chain, create an issue or pull requ
 
 -   --add-activated-chain Add chains from the chain selection (default: "")
 -   --add-foundry Create Foundry settings, remapping and test utilities (default: "")
+-   --add-foundry-test-utility Install the foundry-test-utility npm package and add its remapping (default: "")
 -   --add-github-test-workflow Create Github test workflows (default: "")
 -   --add-hardhat-plugin Add other Hardhat plugins (default: "")
 -   --exclude-contract-file Exclude contract file from the contract selection list (default: "")

--- a/src/buildFoundrySetting.ts
+++ b/src/buildFoundrySetting.ts
@@ -2,6 +2,49 @@ import fs from 'fs'
 import path from 'path'
 
 import { DefaultFoundryTestUtilsList } from './config.ts'
+import detectPackage from './packageInstaller.ts'
+
+// Name of the companion npm package providing shared Forge test utilities and
+// mocks. See https://github.com/marc-aurele-besner/foundry-test-utility.
+export const FOUNDRY_TEST_UTILITY_PACKAGE = 'foundry-test-utility'
+
+/**
+ * Remapping used by Foundry to locate the `foundry-test-utility` package when
+ * it is installed via npm/yarn (vs. `forge install`, which lands under `libs/`).
+ */
+export const FOUNDRY_TEST_UTILITY_REMAPPING = `foundry-test-utility/contracts/=node_modules/${FOUNDRY_TEST_UTILITY_PACKAGE}/contracts`
+
+/**
+ * Append the npm-installed `foundry-test-utility` remapping to `remappings.txt`
+ * if it isn't already there. `remappings.txt` is created by `buildFoundrySetting`
+ * but the file may have been edited by hand, so we only append the new line.
+ */
+export const addFoundryTestUtilityRemapping = () => {
+    const remappingsPath = 'remappings.txt'
+    if (!fs.existsSync(remappingsPath)) return
+    const currentRemappings = fs.readFileSync(remappingsPath, 'utf8')
+    if (currentRemappings.includes(FOUNDRY_TEST_UTILITY_REMAPPING)) {
+        console.log(
+            '\x1b[33m%s\x1b[0m',
+            'The foundry-test-utility remapping already exists in remappings.txt'
+        )
+        return
+    }
+    const separator = currentRemappings.endsWith('\n') || currentRemappings.length === 0 ? '' : '\n'
+    fs.appendFileSync(remappingsPath, separator + FOUNDRY_TEST_UTILITY_REMAPPING + '\n')
+    console.log('\x1b[32m%s\x1b[0m', 'Adding foundry-test-utility remapping to remappings.txt')
+}
+
+/**
+ * Install the `foundry-test-utility` npm package as a dev dependency and add
+ * its remapping to `remappings.txt`. Safe to call repeatedly — the package
+ * installer is a no-op when the package is already present, and the remapping
+ * helper refuses to duplicate the line.
+ */
+export const installFoundryTestUtility = async () => {
+    await detectPackage(FOUNDRY_TEST_UTILITY_PACKAGE, true, false, false)
+    addFoundryTestUtilityRemapping()
+}
 
 const buildFoundrySetting = async () => {
     if (!fs.existsSync('foundry.toml')) {
@@ -82,6 +125,10 @@ block_difficulty = 0                                          # the value of blo
             })
         }
     }
+    // Pull in the shared `foundry-test-utility` package (issue #88) so users
+    // have access to the mock contracts / utilities shipped there in addition
+    // to the bundled cheatcodes copied above.
+    await installFoundryTestUtility()
 }
 
 export default buildFoundrySetting

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -52,6 +52,11 @@ const cliTask: NewTaskDefinition = task('cli', 'Easy command line interface to u
         defaultValue: ''
     })
     .addOption({
+        name: 'addFoundryTestUtility',
+        description: 'Install the foundry-test-utility npm package and add its remapping',
+        defaultValue: ''
+    })
+    .addOption({
         name: 'addActivatedChain',
         description: 'Add chains from the chain selection',
         defaultValue: ''

--- a/src/serveInquirer.ts
+++ b/src/serveInquirer.ts
@@ -11,7 +11,7 @@ import {
     buildScriptsList,
     buildTestsList
 } from './buildFilesList.ts'
-import buildFoundrySetting from './buildFoundrySetting.ts'
+import buildFoundrySetting, { installFoundryTestUtility } from './buildFoundrySetting.ts'
 import buildMockContract, { buildMockDeploymentScriptOrTest } from './buildMockContracts.ts'
 import {
     addActivatedChain,
@@ -513,6 +513,7 @@ const serveMoreSettingSelector = async (env: any) => {
                     new inquirer.Separator(),
                     'Create Github test workflows',
                     'Create Foundry settings, remapping and test utilities',
+                    'Add foundry-test-utility (npm package for shared Forge mocks & utilities)',
                     new inquirer.Separator()
                 ]
             }
@@ -531,6 +532,11 @@ const serveMoreSettingSelector = async (env: any) => {
             if (moreSettingsSelected.moreSettings === 'Create Github test workflows') await serveWorkflowBuilder()
             if (moreSettingsSelected.moreSettings === 'Create Foundry settings, remapping and test utilities')
                 await buildFoundrySetting()
+            if (
+                moreSettingsSelected.moreSettings ===
+                'Add foundry-test-utility (npm package for shared Forge mocks & utilities)'
+            )
+                await installFoundryTestUtility()
         })
 }
 
@@ -793,6 +799,10 @@ const serveCli = async (args: any, env: any) => {
             return buildWorkflowsFromCommand(args.addGithubTestWorkflow)
         case args.addFoundry === true || args.addFoundry === 'true' || args.addFoundry === 'yes':
             return buildFoundrySetting()
+        case args.addFoundryTestUtility === true ||
+            args.addFoundryTestUtility === 'true' ||
+            args.addFoundryTestUtility === 'yes':
+            return installFoundryTestUtility()
         case args.addActivatedChain !== '':
             return addActivatedChain(args.addActivatedChain)
         case args.removeActivatedChain !== '':

--- a/test/buildFoundrySetting.test.ts
+++ b/test/buildFoundrySetting.test.ts
@@ -1,0 +1,61 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import {
+    FOUNDRY_TEST_UTILITY_REMAPPING,
+    addFoundryTestUtilityRemapping
+} from '../src/buildFoundrySetting.ts'
+
+describe('buildFoundrySetting', function () {
+    describe('addFoundryTestUtilityRemapping', function () {
+        const initialCwd = process.cwd()
+        let fixtureDirectory: string
+
+        beforeEach(function () {
+            fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-foundry-'))
+            process.chdir(fixtureDirectory)
+        })
+
+        afterEach(function () {
+            process.chdir(initialCwd)
+            fs.rmSync(fixtureDirectory, { recursive: true, force: true })
+        })
+
+        it('appends the remapping when remappings.txt exists', function () {
+            fs.writeFileSync('remappings.txt', 'hardhat/=node_modules/hardhat/\n')
+
+            addFoundryTestUtilityRemapping()
+
+            const contents = fs.readFileSync('remappings.txt', 'utf8')
+            expect(contents).to.include(FOUNDRY_TEST_UTILITY_REMAPPING)
+        })
+
+        it('does nothing when remappings.txt is missing', function () {
+            // Should silently bail without creating remappings.txt
+            addFoundryTestUtilityRemapping()
+            expect(fs.existsSync('remappings.txt')).to.equal(false)
+        })
+
+        it('does not duplicate the remapping when it already exists', function () {
+            const original = `hardhat/=node_modules/hardhat/\n${FOUNDRY_TEST_UTILITY_REMAPPING}\n`
+            fs.writeFileSync('remappings.txt', original)
+
+            addFoundryTestUtilityRemapping()
+
+            const contents = fs.readFileSync('remappings.txt', 'utf8')
+            const matches = contents.match(new RegExp(FOUNDRY_TEST_UTILITY_REMAPPING.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'))
+            expect(matches?.length).to.equal(1)
+        })
+
+        it('adds a leading newline when remappings.txt does not end with one', function () {
+            fs.writeFileSync('remappings.txt', 'hardhat/=node_modules/hardhat/')
+
+            addFoundryTestUtilityRemapping()
+
+            const contents = fs.readFileSync('remappings.txt', 'utf8')
+            expect(contents).to.equal(`hardhat/=node_modules/hardhat/\n${FOUNDRY_TEST_UTILITY_REMAPPING}\n`)
+        })
+    })
+})


### PR DESCRIPTION
Closes #88.

When users opt into Foundry via \`Create Foundry settings, remapping and test utilities\`, this PR also installs the \`foundry-test-utility\` npm package (no-op if already present) and appends the corresponding remapping to \`remappings.txt\`.

## Changes

- **\`buildFoundrySetting.ts\`**
  - New \`installFoundryTestUtility()\` helper: installs the package via the existing \`detectPackage()\` flow, then \`addFoundryTestUtilityRemapping()\` appends the remapping if not already present.
  - \`buildFoundrySetting()\` calls the helper as its last step.
- **\`serveInquirer.ts\`**
  - New \`More settings\` entry: \`Add foundry-test-utility (npm package for shared Forge mocks & utilities)\`.
  - \`serveCli()\` handles the new \`--add-foundry-test-utility\` flag (mirrors \`--add-foundry\`).
- **\`plugin/index.ts\`**
  - Registers the \`addFoundryTestUtility\` option on the \`cli\` task.
- **\`test/buildFoundrySetting.test.ts\`** (new)
  - 4 unit tests cover the remapping helper: create, missing-file, dedup, leading-newline.
- **\`README.md\`**
  - Documents the new menu entry and the new \`--add-foundry-test-utility\` flag.

## Verification

- \`npm run lint\` ✅
- \`npm test\` → 40 passing (including the 4 new tests) ✅

The pre-existing \`.ts\` import-path errors from \`npm run build\` are unrelated to this PR (they reproduce on a clean checkout of \`main\`).