### PR TITLE
feat: print equivalent CLI command for settings menu selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,20 @@ In 'More settings' you can also add a custom chain, create an issue or pull requ
 -   --remove-activated-chain Remove chains from the chain selection (default: "")
 -   --remove-hardhat-plugin Remove other Hardhat plugins (default: "")
 
+### Equivalent CLI command per menu selection
+
+When a menu selection maps to one of the CLI flags above (add/remove Hardhat plugins, add/remove activated chains, create GitHub workflows, install Foundry settings, install the Foundry test utility, …), the CLI prints the equivalent `npx hardhat cli --<flag> <value>` command line after the change is applied. This lets you skip the interactive prompts next time around, or wire the same action into a CI script.
+
+```commandline
+Equivalent CLI command:  npx hardhat cli --addHardhatPlugin @nomiclabs/hardhat-ethers
+```
+
+Boolean flags (no value) are rendered without an argument:
+
+```commandline
+Equivalent CLI command:  npx hardhat cli --addFoundry
+```
+
 ## Helper tools
 
 Tools that you can use in your scripts and tests to make your life easier
@@ -436,6 +450,7 @@ Return (also printed as a table with `console.table`):
 - Write some test on the package using mocha
 - List all public and external function selectors of a contract (from the CLI menu or with the FunctionList helper)
 - Add optional flag to "cli" command to access some functionality
+- Print the equivalent `npx hardhat cli --flag value` command line for each settings menu selection that maps to a CLI flag
 </details>
 
 ## Directory Tree

--- a/src/serveInquirer.ts
+++ b/src/serveInquirer.ts
@@ -39,6 +39,7 @@ import {
     IMockContractsList
 } from './types.ts'
 import {
+    displayFinalCliCommand,
     inquirerFileContractsAddressDeployed,
     inquirerFileContractsAddressDeployedHistory,
     inquirerFlattenContracts,
@@ -321,8 +322,10 @@ const serveSettingSelector = async (env: any) => {
                         fullChainList.map(async (chain: string) => {
                             if (chainListSelected.chainList.includes(chain)) {
                                 await addActivatedChain(chain)
+                                displayFinalCliCommand('addActivatedChain', chain)
                             } else {
                                 await removeActivatedChain(chain)
+                                displayFinalCliCommand('removeActivatedChain', chain)
                             }
                         })
                         console.log('\x1b[32m%s\x1b[0m', 'Settings updated!')
@@ -490,6 +493,7 @@ const serveWorkflowBuilder = async () => {
         })
     if (workflowToAdd !== undefined) {
         await buildWorkflows(workflowToAdd)
+        displayFinalCliCommand('addGithubTestWorkflow', workflowToAdd.file)
         await sleep(2000)
     }
 }
@@ -530,13 +534,17 @@ const serveMoreSettingSelector = async (env: any) => {
             if (moreSettingsSelected.moreSettings === 'Add other Hardhat plugins') await servePackageInstaller()
             if (moreSettingsSelected.moreSettings === 'Remove other Hardhat plugins') await servePackageUninstaller()
             if (moreSettingsSelected.moreSettings === 'Create Github test workflows') await serveWorkflowBuilder()
-            if (moreSettingsSelected.moreSettings === 'Create Foundry settings, remapping and test utilities')
+            if (moreSettingsSelected.moreSettings === 'Create Foundry settings, remapping and test utilities') {
                 await buildFoundrySetting()
+                displayFinalCliCommand('addFoundry')
+            }
             if (
                 moreSettingsSelected.moreSettings ===
                 'Add foundry-test-utility (npm package for shared Forge mocks & utilities)'
-            )
+            ) {
                 await installFoundryTestUtility()
+                displayFinalCliCommand('addFoundryTestUtility')
+            }
         })
 }
 
@@ -575,6 +583,7 @@ const servePackageInstaller = async () => {
         })
     if (packageToInstall !== undefined) {
         await detectPackage(packageToInstall.name, true, false, packageToInstall.addInHardhatConfig)
+        displayFinalCliCommand('addHardhatPlugin', packageToInstall.name)
         await sleep(5000)
     }
 }
@@ -603,8 +612,10 @@ const servePackageUninstaller = async () => {
             })
             await sleep(1500)
         })
-    if (packageToUninstall !== undefined)
+    if (packageToUninstall !== undefined) {
         await detectPackage(packageToUninstall.name, false, true, packageToUninstall.addInHardhatConfig)
+        displayFinalCliCommand('removeHardhatPlugin', packageToUninstall.name)
+    }
     await sleep(5000)
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,6 +77,30 @@ export const runCommand = async (
 }
 
 /**
+ * Build the `npx hardhat cli --flagName value` command line that reproduces
+ * the current menu selection, so the user can skip the interactive prompts
+ * next time. When `value` is an array every entry is appended as its own
+ * `--flagName <entry>` pair so the CLI accepts the full batch.
+ */
+export const buildFinalCliCommand = (flagName: string, value: string | string[]): string => {
+    const values = Array.isArray(value) ? value : [value]
+    return ['npx hardhat cli', ...values.map((entry) => `--${flagName} ${entry}`)].join(' ')
+}
+
+/**
+ * Print the equivalent CLI command for a menu selection. Used by the
+ * settings flows (exclude files, install/uninstall plugins, create
+ * workflows, add/remove chains, ...) to teach users how to skip the
+ * interactive prompts next time. When `value` is omitted, the flag is
+ * rendered as a boolean (e.g. `--addFoundry`).
+ */
+export const displayFinalCliCommand = (flagName: string, value?: string | string[]): string => {
+    const command = value === undefined ? `npx hardhat cli --${flagName}` : buildFinalCliCommand(flagName, value)
+    console.log('\x1b[33m%s\x1b[0m', 'Equivalent CLI command: ', '\x1b[97m\x1b[0m', command)
+    return command
+}
+
+/**
  * List every public and external function of a compiled contract with its
  * 4 bytes function selector, sorted by selector (ascending).
  *

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,6 @@
 import { assert, expect } from 'chai'
 
-import { buildCommand } from '../src/utils.ts'
+import { buildCommand, buildFinalCliCommand, displayFinalCliCommand } from '../src/utils.ts'
 import { usePathsEnvironment } from './helpers'
 
 describe('Integration tests', function () {
@@ -33,5 +33,29 @@ describe('Command builder', function () {
         expect(buildCommand('npm run deploy', 'npm install', ' --network sepolia')).to.equal(
             'npm install --network sepolia && npm run deploy --network sepolia'
         )
+    })
+})
+
+describe('Final CLI command builder', function () {
+    it('builds a single-flag command with one value', function () {
+        expect(buildFinalCliCommand('addHardhatPlugin', '@nomiclabs/hardhat-ethers')).to.equal(
+            'npx hardhat cli --addHardhatPlugin @nomiclabs/hardhat-ethers'
+        )
+    })
+
+    it('builds a single-flag command with multiple values', function () {
+        expect(buildFinalCliCommand('addActivatedChain', ['ethereum', 'polygon'])).to.equal(
+            'npx hardhat cli --addActivatedChain ethereum --addActivatedChain polygon'
+        )
+    })
+
+    it('renders a boolean flag when no value is supplied', function () {
+        const command = displayFinalCliCommand('addFoundry')
+        expect(command).to.equal('npx hardhat cli --addFoundry')
+    })
+
+    it('renders a flag with a value when one is supplied', function () {
+        const command = displayFinalCliCommand('addGithubTestWorkflow', 'hardhat-npm')
+        expect(command).to.equal('npx hardhat cli --addGithubTestWorkflow hardhat-npm')
     })
 })


### PR DESCRIPTION
Closes #39

Extends the `runCommand`-style command display to every settings menu flow that maps to an existing CLI flag:

* Add / remove Hardhat plugin
* Add / remove activated chain
* Create GitHub test workflow
* Create Foundry settings
* Install the Foundry test utility

The CLI now prints the equivalent `npx hardhat cli --<flag> <value>` line after the change is applied, so users can skip the interactive prompts next time or wire the same action into a CI script.

## Changes

* Extract `buildFinalCliCommand` and `displayFinalCliCommand` helpers in `src/utils.ts` (one returns the string, the other prints it via the same yellow / white ANSI helpers used by `runCommand`).
* Call `displayFinalCliCommand` from `serveInquirer` after each settings change that already has a CLI flag.
* Document the new behaviour in the README under a new "Equivalent CLI command per menu selection" subsection and in the "Done" checklist.
* Cover `buildFinalCliCommand` and `displayFinalCliCommand` with four new tests in `test/cli.test.ts` (single value, multiple values, boolean flag, flag with value).

## Verification

```
$ npm test
44 passing (211ms)

$ npm run lint
(no output, clean)

$ npx prettier --check src/utils.ts src/serveInquirer.ts test/cli.test.ts
All matched files use Prettier code style!
```