### PR TITLE
fix: bin entry, fs stub dep, and license badge (#154)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![license](https://img.shields.io/github/license/jamesisaac/react-native-background-task.svg)](https://opensource.org/licenses/MIT)
+[![license](https://img.shields.io/github/license/marc-aurele-besner/hardhat-awesome-cli.svg)](https://opensource.org/licenses/MIT)
 [![npm version](https://badge.fury.io/js/hardhat-awesome-cli.svg)](https://badge.fury.io/js/hardhat-awesome-cli)
 
 # 👷 hardhat-awesome-cli

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "inquirer": "^14.0.0"
             },
             "bin": {
-                "hardhat-awesome-cli": "src/index.ts"
+                "hardhat-awesome-cli": "dist/src/index.js"
             },
             "devDependencies": {
                 "@babel/core": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "dependencies": {
                 "dotenv": "^17.0.0",
-                "fs": "^0.0.1-security",
                 "inquirer": "^14.0.0"
             },
             "bin": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     },
     "dependencies": {
         "dotenv": "^17.0.0",
-        "fs": "^0.0.1-security",
         "inquirer": "^14.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "./plugin": "./dist/src/plugin/index.js"
     },
     "bin": {
-        "hardhat-awesome-cli": "./src/index.ts"
+        "hardhat-awesome-cli": "./dist/src/index.js"
     },
     "bugs": {
         "url": "https://github.com/marc-aurele-besner/hardhat-awesome-cli/issues"

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -11,7 +11,8 @@
         "rootDirs": ["./src", "./test"],
         "types": ["node", "mocha"],
         "esModuleInterop": true,
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "rewriteRelativeImportExtensions": true
     },
     "exclude": ["dist", "node_modules"],
     "include": ["./test", "./src"]


### PR DESCRIPTION
Closes #154

Three small packaging/metadata fixes split into separate commits:

- **docs: fix license badge URL in README** — shields.io badge pointed at jamesisaac/react-native-background-task; now points at this repo.
- **fix: drop stub fs dependency** — the "fs" npm package is the well-known "do not install" stub. All imports in this codebase use Node's built-in `fs`; removing the dep avoids noise and confusion for downstream users.
- **fix: point published bin at compiled dist entry** — `bin` previously pointed at `src/index.ts`, which Node can't run directly. Now points at `dist/src/index.js` and the prod tsconfig enables `rewriteRelativeImportExtensions` so the emitted relative imports end in `.js` (Node ESM requires explicit extensions). The compiled entry keeps its `#!/usr/bin/env node` shebang.

Verified locally:
- `npm test` — 44 passing.
- `npm run build` — emits `dist/src/index.js` with rewritten imports.
- `node dist/src/index.js` — module graph loads cleanly and the inquirer prompt starts.

Acceptance criteria from #154:
- [x] `npx hardhat-awesome-cli` works from a published/packed tarball (dist entry + shebang preserved)
- [x] No `fs` package in `dependencies`
- [x] License badge points at this project