### PR TITLE
test: cover retrieveOZAdminProxyContract chainId mapping (closes #151)

### DIFF
--- a/test/addressBook.test.ts
+++ b/test/addressBook.test.ts
@@ -301,5 +301,41 @@ describe('Integration tests', function () {
             expect(fs.unlinkSync('contractsAddressDeployedHistory.json')).to.be.equal(undefined)
             expect(fs.existsSync('contractsAddressDeployedHistory.json')).to.be.equal(false)
         })
+
+        describe('retrieveOZAdminProxyContract', function () {
+            const ozDir = '.openzeppelin'
+            const mainnetAdmin = '0x0000000000000000000000000000000000000abc'
+            const sepoliaAdmin = '0x0000000000000000000000000000000000000def'
+
+            beforeEach(function () {
+                if (!fs.existsSync(ozDir)) fs.mkdirSync(ozDir)
+                fs.writeFileSync(
+                    `${ozDir}/mainnet.json`,
+                    JSON.stringify({ admin: { address: mainnetAdmin } })
+                )
+                fs.writeFileSync(
+                    `${ozDir}/sepolia.json`,
+                    JSON.stringify({ admin: { address: sepoliaAdmin } })
+                )
+            })
+
+            afterEach(function () {
+                if (fs.existsSync(`${ozDir}/mainnet.json`)) fs.unlinkSync(`${ozDir}/mainnet.json`)
+                if (fs.existsSync(`${ozDir}/sepolia.json`)) fs.unlinkSync(`${ozDir}/sepolia.json`)
+                if (fs.existsSync(ozDir)) fs.rmdirSync(ozDir)
+            })
+
+            it('returns the mainnet admin address for chainId 1', function () {
+                expect(this.addressBook.retrieveOZAdminProxyContract(1)).to.be.equal(mainnetAdmin)
+            })
+
+            it('returns the sepolia admin address for chainId 11155111', function () {
+                expect(this.addressBook.retrieveOZAdminProxyContract(11155111)).to.be.equal(sepoliaAdmin)
+            })
+
+            it('returns an empty string for an unknown chainId', function () {
+                expect(this.addressBook.retrieveOZAdminProxyContract(999999)).to.be.equal('')
+            })
+        })
     })
 })


### PR DESCRIPTION
Closes #151.

The switch in `AwesomeAddressBook.retrieveOZAdminProxyContract` previously fell through to the `default` branch (no break statements), so `ozFileName` was always `unknown-<chainId>` and the function never resolved the right OpenZeppelin artifacts folder. The missing breaks were added in e449aeb; this PR adds the unit tests required by the issue's acceptance criteria.

## Changes

- Adds a nested `retrieveOZAdminProxyContract` describe block in `test/addressBook.test.ts` that writes fixture `.openzeppelin/mainnet.json` and `.openzeppelin/sepolia.json` files in `beforeEach` and removes them in `afterEach`.

## Covered cases

- `chainId 1` (mainnet) returns the admin address from `.openzeppelin/mainnet.json`
- `chainId 11155111` (sepolia) returns the admin address from `.openzeppelin/sepolia.json`
- An unknown `chainId` returns an empty string without throwing

The first two tests double as regression tests for the original fallthrough bug: with no `break` statements, `ozFileName` would always be `unknown-1` and the function would read the wrong file (or nothing), failing the assertions.

## Verification

- `npm run lint` — clean
- `npm test` — 47 passing (3 new)