### PR TITLE
fix: refresh generated GitHub workflow templates and yarn group metadata (closes #160)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -227,13 +227,13 @@ export const DefaultGithubWorkflowsList: IDefaultGithubWorkflowsList[] = [
     {
         title: 'Yarn - Hardhat - Test & Coverage',
         file: 'hardhat-yarn',
-        group: 'npm',
+        group: 'yarn',
         requirement: ['solidity-coverage']
     },
     {
         title: 'Yarn - Foundry - Forge Test',
         file: 'foundry-yarn',
-        group: 'npm'
+        group: 'yarn'
     }
 ]
 

--- a/src/githubWorkflows/foundry-npm.yml
+++ b/src/githubWorkflows/foundry-npm.yml
@@ -6,15 +6,15 @@ jobs:
   test_foundry_npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: 16
+          node-version: 20
       - name: Install Foundry
         uses: onbjerg/foundry-toolchain@v1
         with:
           version: nightly
-      - name: Yarn Install
-        run: yarn
+      - name: NPM Install
+        run: npm install
       - name: Run Forge Test
         run: forge test

--- a/src/githubWorkflows/foundry-yarn.yml
+++ b/src/githubWorkflows/foundry-yarn.yml
@@ -6,15 +6,15 @@ jobs:
   test_foundry_yarn:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: 16
+          node-version: 20
       - name: Install Foundry
         uses: onbjerg/foundry-toolchain@v1
         with:
           version: nightly
-      - name: NPM Install
-        run: npm install
+      - name: Yarn Install
+        run: yarn
       - name: Run Forge Test
         run: forge test

--- a/src/githubWorkflows/hardhat-npm.yml
+++ b/src/githubWorkflows/hardhat-npm.yml
@@ -8,7 +8,10 @@ jobs:
   test_hardhat_npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
       - name: NPM Clean Install
         run: npm ci
       - name: Hardhat Compile

--- a/src/githubWorkflows/hardhat-yarn.yml
+++ b/src/githubWorkflows/hardhat-yarn.yml
@@ -8,7 +8,10 @@ jobs:
   test_hardhat_yarn:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
       - name: Yarn Install
         run: yarn
       - name: Hardhat Compile

--- a/test/githubWorkflows.test.ts
+++ b/test/githubWorkflows.test.ts
@@ -1,0 +1,80 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import path from 'path'
+
+import { DefaultGithubWorkflowsList } from '../src/config.ts'
+import type { IDefaultGithubWorkflowsList } from '../src/types.ts'
+
+const WORKFLOW_YAML_DIR = path.join(__dirname, '..', 'src', 'githubWorkflows')
+
+describe('DefaultGithubWorkflowsList group metadata', function () {
+    it('Tags the Hardhat yarn workflow with group "yarn"', function () {
+        const yarnHardhat = DefaultGithubWorkflowsList.find(
+            (workflow: IDefaultGithubWorkflowsList) => workflow.file === 'hardhat-yarn'
+        )
+        expect(yarnHardhat, 'hardhat-yarn workflow missing from config').to.not.equal(undefined)
+        expect(yarnHardhat!.group).to.equal('yarn')
+    })
+
+    it('Tags the Foundry yarn workflow with group "yarn"', function () {
+        const yarnFoundry = DefaultGithubWorkflowsList.find(
+            (workflow: IDefaultGithubWorkflowsList) => workflow.file === 'foundry-yarn'
+        )
+        expect(yarnFoundry, 'foundry-yarn workflow missing from config').to.not.equal(undefined)
+        expect(yarnFoundry!.group).to.equal('yarn')
+    })
+
+    it('Keeps npm workflows tagged with group "npm"', function () {
+        const npmWorkflows = DefaultGithubWorkflowsList.filter(
+            (workflow: IDefaultGithubWorkflowsList) => workflow.file.endsWith('-npm')
+        )
+        expect(npmWorkflows.length).to.be.greaterThan(0)
+        npmWorkflows.forEach((workflow: IDefaultGithubWorkflowsList) => {
+            expect(workflow.group).to.equal('npm')
+        })
+    })
+
+    it('Has one npm and one yarn entry per tooling (Hardhat / Foundry)', function () {
+        // Guards against the original bug where every entry was tagged npm,
+        // which made serveWorkflowBuilder list both yarn items under "npm".
+        const groupCounts = DefaultGithubWorkflowsList.reduce<Record<string, number>>((counts, workflow) => {
+            counts[workflow.group] = (counts[workflow.group] ?? 0) + 1
+            return counts
+        }, {})
+        expect(groupCounts.npm).to.equal(2)
+        expect(groupCounts.yarn).to.equal(2)
+    })
+})
+
+describe('Generated GitHub workflow YAMLs', function () {
+    const yamlFiles = ['hardhat-npm.yml', 'hardhat-yarn.yml', 'foundry-npm.yml', 'foundry-yarn.yml']
+
+    yamlFiles.forEach((fileName: string) => {
+        describe(fileName, function () {
+            const content = fs.readFileSync(path.join(WORKFLOW_YAML_DIR, fileName), 'utf8')
+
+            it('Uses a current major of actions/checkout (>= v4)', function () {
+                // Pin to v7 to match the rest of the project's own workflows;
+                // the assertion allows a forward bump without editing the test.
+                expect(content).to.match(/uses:\s*actions\/checkout@v(4|5|6|7|8|9)/)
+            })
+
+            it('Sets up Node with a maintained major (>= v4)', function () {
+                expect(content).to.match(/uses:\s*actions\/setup-node@v(4|5|6|7|8|9)/)
+            })
+
+            it('Targets a current LTS Node version (>= 20)', function () {
+                expect(content).to.match(/node-version:\s*["']?(2[0-9]|3[0-9])/)
+            })
+
+            it('Mentions the install command that matches its group', function () {
+                if (fileName.includes('yarn')) {
+                    expect(content).to.include('yarn')
+                    expect(content).to.not.match(/npm ci\b/)
+                } else {
+                    expect(content).to.match(/npm (ci|install)/)
+                }
+            })
+        })
+    })
+})


### PR DESCRIPTION
## Summary

Closes #160. The generated GitHub workflow templates and their menu grouping metadata were both stale.

### Workflow YAMLs (`src/githubWorkflows/*.yml`)
- Bump `actions/checkout` v2 → v7 (matches this repo's own CI)
- Bump `actions/setup-node` v3 → v7 and pin `node-version` to 20 (Hardhat 3 baseline)
- Add `setup-node` to `hardhat-npm.yml` / `hardhat-yarn.yml`, which were missing it entirely
- Fix swapped install commands: `foundry-npm.yml` was running `yarn`, `foundry-yarn.yml` was running `npm install`. Each file now matches its filename.

### Config (`src/config.ts`)
- Both Yarn entries in `DefaultGithubWorkflowsList` were tagged `group: 'npm'`. `serveWorkflowBuilder` filters by group, so the menu listed all four workflows under the 'npm' header with no yarn section. Switch them to `group: 'yarn'`.

### Tests (`test/githubWorkflows.test.ts`)
- New suite pins the yarn entries to `group: 'yarn'` and asserts the npm/yarn split is balanced (2/2), guarding the specific regression.
- New suite walks every template and asserts `actions/checkout` and `actions/setup-node` are on a maintained major and Node is ≥ 20.

## Verification
- `npm test`: 67 passing (20 new)
- `npm run lint`: clean
- `npm run build`: no new errors (pre-existing TypeScript errors in mock deployment scripts and the project's own `hardhat.config.ts` are unrelated)