### PR TITLE
fix(mocks): create contracts/, scripts/, and test/ when adding mocks (closes #168)

### DIFF
--- a/src/buildMockContracts.ts
+++ b/src/buildMockContracts.ts
@@ -30,97 +30,98 @@ const resolveMockContractsPath = (): string | undefined => {
 
 const buildMockContract = async (contractName: string) => {
     const packageRootPath = resolveMockContractsPath()
-    if (packageRootPath) {
-        if (fs.existsSync('contracts')) {
-            if (MockContractsList) {
-                const contractToMock: IMockContractsList[] = MockContractsList.filter(
-                    (contract) => contract.name === contractName
-                )
-                if (contractToMock) {
-                    if (fs.existsSync('contracts/' + contractName + '.sol'))
-                        console.log('\x1b[33m%s\x1b[0m', 'Mock contract already exists')
-                    else {
-                        console.log('\x1b[32m%s\x1b[0m', 'Creating ', contractName, ' in contracts/')
-                        fs.copyFileSync(
-                            packageRootPath + '/' + contractName + '.sol',
-                            'contracts/' + contractName + '.sol'
-                        )
-                    }
-                    if (contractToMock[0].dependencies && contractToMock[0].dependencies.length > 0) {
-                        for (const dependency of contractToMock[0].dependencies) {
-                            // `detectPackage` now awaits the underlying `npm install`
-                            // itself, so there is no need for a fixed post-install sleep.
-                            await detectPackage(dependency, true, false, false)
-                        }
-                    }
-                }
-            }
-        } else console.log('\x1b[33m%s\x1b[0m', 'Error creating mock contract')
+    if (!packageRootPath) return
+
+    // Ensure `contracts/` exists before writing any artifacts. `recursive: true`
+    // makes this a no-op when the directory is already present, so projects that
+    // already ship a `contracts/` folder are not touched (closes #168).
+    fs.mkdirSync('contracts', { recursive: true })
+
+    if (!MockContractsList) return
+
+    const contractToMock: IMockContractsList[] = MockContractsList.filter(
+        (contract) => contract.name === contractName
+    )
+    if (contractToMock.length === 0) return
+
+    const contractFile = `contracts/${contractName}.sol`
+    if (fs.existsSync(contractFile)) {
+        console.log('\x1b[33m%s\x1b[0m', 'Mock contract already exists')
+        return
+    }
+
+    console.log('\x1b[32m%s\x1b[0m', 'Creating ', contractName, ' in contracts/')
+    fs.copyFileSync(path.join(packageRootPath, `${contractName}.sol`), contractFile)
+
+    if (contractToMock[0].dependencies && contractToMock[0].dependencies.length > 0) {
+        for (const dependency of contractToMock[0].dependencies) {
+            // `detectPackage` now awaits the underlying `npm install`
+            // itself, so there is no need for a fixed post-install sleep.
+            await detectPackage(dependency, true, false, false)
+        }
     }
 }
 
 export const buildMockDeploymentScriptOrTest = async (contractName: string, type: string) => {
     const packageRootPath = resolveMockContractsPath()
-    if (packageRootPath) {
-        if (fs.existsSync('contracts')) {
-            if (MockContractsList) {
-                let deploymentScriptOrTestPath: string = ''
-                let finalPath: string = ''
-                let scriptOrTestDir: string = ''
-                const contractToMock: IMockContractsList[] = MockContractsList.filter(
-                    (contract) => contract.name === contractName
-                )
-                if (contractToMock && type === 'deployment') {
-                    scriptOrTestDir = 'scripts'
-                    if (fs.existsSync('hardhat.config.js')) {
-                        if (contractToMock[0].deploymentScriptJs !== undefined)
-                            deploymentScriptOrTestPath = contractToMock[0].deploymentScriptJs
-                    } else if (fs.existsSync('hardhat.config.ts')) {
-                        if (contractToMock[0].deploymentScriptTs !== undefined)
-                            deploymentScriptOrTestPath = contractToMock[0].deploymentScriptTs
-                        else if (contractToMock[0].deploymentScriptJs !== undefined)
-                            deploymentScriptOrTestPath = contractToMock[0].deploymentScriptJs
-                    }
-                    finalPath = deploymentScriptOrTestPath
-                }
-                if (contractToMock && type === 'test') {
-                    scriptOrTestDir = 'test'
-                    if (fs.existsSync('hardhat.config.js')) {
-                        if (contractToMock[0].testScriptJs !== undefined)
-                            deploymentScriptOrTestPath = contractToMock[0].testScriptJs
-                    } else if (fs.existsSync('hardhat.config.ts')) {
-                        if (contractToMock[0].testScriptTs !== undefined)
-                            deploymentScriptOrTestPath = contractToMock[0].testScriptTs
-                        else if (contractToMock[0].testScriptJs !== undefined)
-                            deploymentScriptOrTestPath = contractToMock[0].testScriptJs
-                    }
-                    finalPath = deploymentScriptOrTestPath
-                }
-                if (contractToMock && type === 'testForge') {
-                    scriptOrTestDir = 'contracts/test'
-                    if (contractToMock[0]?.testContractFoundry !== undefined)
-                        deploymentScriptOrTestPath = contractToMock[0].testContractFoundry
-                    finalPath = deploymentScriptOrTestPath.replace('testForge/', 'contracts/test/')
-                }
-                if (contractToMock && deploymentScriptOrTestPath && finalPath) {
-                    if (fs.existsSync(finalPath))
-                        console.log('\x1b[33m%s\x1b[0m', 'The ' + type + ' in ' + scriptOrTestDir + '/ already exists')
-                    else {
-                        console.log(
-                            '\x1b[32m%s\x1b[0m',
-                            'Creating ' + type + ' for ',
-                            contractName,
-                            ' in ' + scriptOrTestDir + '/'
-                        )
-                        if (!fs.existsSync(scriptOrTestDir + '/'))
-                            fs.mkdirSync(scriptOrTestDir + '/', { recursive: true })
-                        const rawData: any = fs.readFileSync(packageRootPath + '/' + deploymentScriptOrTestPath)
-                        fs.writeFileSync(finalPath, rawData)
-                    }
-                }
-            }
-        } else console.log('\x1b[33m%s\x1b[0m', 'Error creating ' + type + ' script')
+    if (!packageRootPath) return
+    if (!MockContractsList) return
+
+    let deploymentScriptOrTestPath: string = ''
+    let finalPath: string = ''
+    let scriptOrTestDir: string = ''
+    const contractToMock: IMockContractsList[] = MockContractsList.filter(
+        (contract) => contract.name === contractName
+    )
+    if (contractToMock.length === 0) return
+
+    if (type === 'deployment') {
+        scriptOrTestDir = 'scripts'
+        if (fs.existsSync('hardhat.config.js')) {
+            if (contractToMock[0].deploymentScriptJs !== undefined)
+                deploymentScriptOrTestPath = contractToMock[0].deploymentScriptJs
+        } else if (fs.existsSync('hardhat.config.ts')) {
+            if (contractToMock[0].deploymentScriptTs !== undefined)
+                deploymentScriptOrTestPath = contractToMock[0].deploymentScriptTs
+            else if (contractToMock[0].deploymentScriptJs !== undefined)
+                deploymentScriptOrTestPath = contractToMock[0].deploymentScriptJs
+        }
+        finalPath = deploymentScriptOrTestPath
+    } else if (type === 'test') {
+        scriptOrTestDir = 'test'
+        if (fs.existsSync('hardhat.config.js')) {
+            if (contractToMock[0].testScriptJs !== undefined)
+                deploymentScriptOrTestPath = contractToMock[0].testScriptJs
+        } else if (fs.existsSync('hardhat.config.ts')) {
+            if (contractToMock[0].testScriptTs !== undefined)
+                deploymentScriptOrTestPath = contractToMock[0].testScriptTs
+            else if (contractToMock[0].testScriptJs !== undefined)
+                deploymentScriptOrTestPath = contractToMock[0].testScriptJs
+        }
+        finalPath = deploymentScriptOrTestPath
+    } else if (type === 'testForge') {
+        scriptOrTestDir = 'contracts/test'
+        if (contractToMock[0]?.testContractFoundry !== undefined)
+            deploymentScriptOrTestPath = contractToMock[0].testContractFoundry
+        finalPath = deploymentScriptOrTestPath.replace('testForge/', 'contracts/test/')
     }
+
+    if (!deploymentScriptOrTestPath || !finalPath) return
+
+    // Ensure the destination directory exists before writing. `recursive: true`
+    // is a no-op when the directory is already there, so this is safe to run
+    // unconditionally — projects with an existing `scripts/`, `test/`, or
+    // `contracts/test/` folder are left untouched (closes #168).
+    fs.mkdirSync(scriptOrTestDir, { recursive: true })
+
+    if (fs.existsSync(finalPath)) {
+        console.log('\x1b[33m%s\x1b[0m', 'The ' + type + ' in ' + scriptOrTestDir + '/ already exists')
+        return
+    }
+
+    console.log('\x1b[32m%s\x1b[0m', 'Creating ' + type + ' for ', contractName, ' in ' + scriptOrTestDir + '/')
+    const rawData: any = fs.readFileSync(path.join(packageRootPath, deploymentScriptOrTestPath))
+    fs.writeFileSync(finalPath, rawData)
 }
 
 export default buildMockContract

--- a/test/buildMockContracts.test.ts
+++ b/test/buildMockContracts.test.ts
@@ -1,0 +1,155 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import buildMockContract, { buildMockDeploymentScriptOrTest } from '../src/buildMockContracts.ts'
+
+/**
+ * Tests for the mock-contract generator. Issue #168 asked that the mock
+ * creator succeed in projects that do not yet have `contracts/`, `test/`,
+ * and `scripts/` directories, creating them on demand without overwriting
+ * any files that already exist.
+ */
+describe('buildMockContracts (issue #168)', function () {
+    const initialCwd = process.cwd()
+    let fixtureDirectory: string
+
+    // `detectPackage` short-circuits when the dependency already lives under
+    // `node_modules/`, so creating an empty placeholder keeps the install
+    // command from running during tests.
+    const stubOpenZeppelinContracts = () => {
+        fs.mkdirSync(path.join(fixtureDirectory, 'node_modules/@openzeppelin/contracts'), {
+            recursive: true
+        })
+    }
+
+    beforeEach(function () {
+        fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-mocks-'))
+        process.chdir(fixtureDirectory)
+        // Provide a hardhat.config.ts so `buildMockDeploymentScriptOrTest`
+        // picks the TypeScript templates. buildMockContract itself does not
+        // require a Hardhat config.
+        fs.writeFileSync('hardhat.config.ts', 'export default {}\n')
+        stubOpenZeppelinContracts()
+    })
+
+    afterEach(function () {
+        process.chdir(initialCwd)
+        fs.rmSync(fixtureDirectory, { recursive: true, force: true })
+    })
+
+    describe('buildMockContract', function () {
+        it('creates contracts/ when it does not exist', async function () {
+            expect(fs.existsSync('contracts')).to.equal(false)
+
+            await buildMockContract('MockERC20')
+
+            expect(fs.existsSync('contracts')).to.equal(true)
+            expect(fs.existsSync('contracts/MockERC20.sol')).to.equal(true)
+        })
+
+        it('leaves an existing contracts/ directory untouched', async function () {
+            fs.mkdirSync('contracts')
+            const markerFile = path.join('contracts', 'MyContract.sol')
+            fs.writeFileSync(markerFile, '// keep me')
+
+            await buildMockContract('MockERC20')
+
+            // Existing user file is preserved.
+            expect(fs.readFileSync(markerFile, 'utf8')).to.equal('// keep me')
+            // New mock landed next to it.
+            expect(fs.existsSync('contracts/MockERC20.sol')).to.equal(true)
+        })
+
+        it('does not overwrite an existing mock contract', async function () {
+            fs.mkdirSync('contracts')
+            const existingPath = path.join('contracts', 'MockERC20.sol')
+            fs.writeFileSync(existingPath, '// existing user edits')
+
+            await buildMockContract('MockERC20')
+
+            expect(fs.readFileSync(existingPath, 'utf8')).to.equal('// existing user edits')
+        })
+
+        it('is a no-op for an unknown mock contract name', async function () {
+            await buildMockContract('MockThatDoesNotExist')
+
+            // contracts/ should still be created (matches the new behavior),
+            // but no .sol file should be added.
+            expect(fs.existsSync('contracts')).to.equal(true)
+            const entries = fs.readdirSync('contracts')
+            expect(entries.filter((entry) => entry.endsWith('.sol'))).to.deep.equal([])
+        })
+    })
+
+    describe('buildMockDeploymentScriptOrTest', function () {
+        it('creates scripts/ when generating a deployment script', async function () {
+            expect(fs.existsSync('scripts')).to.equal(false)
+
+            await buildMockContract('MockERC20')
+            await buildMockDeploymentScriptOrTest('MockERC20', 'deployment')
+
+            expect(fs.existsSync('scripts')).to.equal(true)
+            expect(fs.existsSync('scripts/deploy-Mock-ERC20.ts')).to.equal(true)
+        })
+
+        it('creates test/ when generating a test script', async function () {
+            expect(fs.existsSync('test')).to.equal(false)
+
+            await buildMockContract('MockERC20')
+            await buildMockDeploymentScriptOrTest('MockERC20', 'test')
+
+            expect(fs.existsSync('test')).to.equal(true)
+            expect(fs.existsSync('test/test-Mock-ERC20.ts')).to.equal(true)
+        })
+
+        it('creates contracts/test/ when generating a Foundry test', async function () {
+            expect(fs.existsSync('contracts/test')).to.equal(false)
+
+            await buildMockContract('MockERC20')
+            await buildMockDeploymentScriptOrTest('MockERC20', 'testForge')
+
+            expect(fs.existsSync('contracts/test')).to.equal(true)
+            expect(fs.existsSync('contracts/test/MockERC20.t.sol')).to.equal(true)
+        })
+
+        it('leaves an existing scripts/ directory and its files untouched', async function () {
+            fs.mkdirSync('scripts')
+            const userScript = path.join('scripts', 'my-deploy.ts')
+            fs.writeFileSync(userScript, '// user script')
+
+            await buildMockContract('MockERC20')
+            await buildMockDeploymentScriptOrTest('MockERC20', 'deployment')
+
+            expect(fs.readFileSync(userScript, 'utf8')).to.equal('// user script')
+            expect(fs.existsSync('scripts/deploy-Mock-ERC20.ts')).to.equal(true)
+        })
+
+        it('does not overwrite an existing deployment script', async function () {
+            fs.mkdirSync('scripts')
+            const existing = path.join('scripts', 'deploy-Mock-ERC20.ts')
+            fs.writeFileSync(existing, '// user edits')
+
+            await buildMockContract('MockERC20')
+            await buildMockDeploymentScriptOrTest('MockERC20', 'deployment')
+
+            expect(fs.readFileSync(existing, 'utf8')).to.equal('// user edits')
+        })
+
+        it('succeeds when none of contracts/, scripts/, or test/ exist yet', async function () {
+            // Sanity check: this is the exact situation from issue #168.
+            expect(fs.existsSync('contracts')).to.equal(false)
+            expect(fs.existsSync('scripts')).to.equal(false)
+            expect(fs.existsSync('test')).to.equal(false)
+
+            await buildMockContract('MockERC20')
+            await buildMockDeploymentScriptOrTest('MockERC20', 'deployment')
+            await buildMockDeploymentScriptOrTest('MockERC20', 'test')
+
+            expect(fs.existsSync('contracts/MockERC20.sol')).to.equal(true)
+            expect(fs.existsSync('scripts/deploy-Mock-ERC20.ts')).to.equal(true)
+            expect(fs.existsSync('test/test-Mock-ERC20.ts')).to.equal(true)
+        })
+    })
+})


### PR DESCRIPTION
## Summary

When the mock-contract creator ran in a project that did not yet have the standard Hardhat layout (`contracts/`, `scripts/`, `test/`), it bailed with `Error creating mock contract` and the deployment/test writers did the same. Users had to scaffold the folders manually before the CLI could do anything.

This change replaces the `fs.existsSync` guards with `fs.mkdirSync(dir, { recursive: true })` so the directories are created on demand:

- `buildMockContract` ensures `contracts/` exists before copying the `.sol` template.
- `buildMockDeploymentScriptOrTest` ensures the destination directory (`scripts/`, `test/`, or `contracts/test/`) exists before writing the deployment script, test, or Foundry test.

`mkdirSync` with `{ recursive: true }` is a no-op when the directory already exists, so projects that already ship the standard layout are not touched and existing files are never overwritten.

## Acceptance criteria (from #168)

- [x] Mock creator succeeds in a project missing those directories
- [x] Folders are created with sensible defaults (no overwrite of existing files)

## Tests

Added `test/buildMockContracts.test.ts` with 10 cases covering:

- `contracts/` is created when missing
- Existing `contracts/` and its files are preserved
- An existing mock `.sol` is not overwritten
- Unknown contract names are a no-op
- `scripts/`, `test/`, and `contracts/test/` are each created when generating the matching artifact
- Existing `scripts/` and an existing deployment script are preserved
- End-to-end: starting from a project with none of the folders, all artifacts land in the right places

The existing test runner (`mocha`) uses a stubbed `node_modules/@openzeppelin/contracts` directory so `detectPackage` short-circuits and no real `npm install` is triggered.

`npm test` — 85 passing. `npm run lint` — clean.

Closes #168