### PR TITLE
refactor(mocks): use a single TS template for mock deploy/test scripts (closes #159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ npm link hardhat-awesome-cli
     -   MockERC1155Upgradeable
     -   MockProxyAdmin
     -   MockTransparentUpgradeableProxy
+
+    > Mock deployment and test scripts are authored as a single TypeScript
+    > source of truth under `src/mockContracts/scripts/` and `src/mockContracts/test/`.
+    > When the consumer project uses `hardhat.config.js`, the CLI generates the
+    > CommonJS variant from the same template at write time — no duplicate files
+    > to keep in sync.
+
 -   Get account balance
 
 ### Current chain support
@@ -495,8 +502,8 @@ hardhat-awesome-cli/
 │   ├── mockContracts/
 │   │   ├── index.ts
 │   │   ├── MockERC20.sol (+ Upgradeable / ERC721 / ERC1155 variants, MockProxyAdmin, MockTransparentUpgradeableProxy)
-│   │   ├── scripts/  # deploy scripts for every mock above
-│   │   ├── test/     # mocha test scripts for every mock above
+│   │   ├── scripts/  # deploy scripts for every mock above (TS source of truth; JS is generated on the fly for hardhat.config.js projects)
+│   │   ├── test/     # mocha test scripts for every mock above (TS source of truth; JS is generated on the fly for hardhat.config.js projects)
 │   │   └── testForge/# Foundry/Forge test contracts + cheatcode utilities
 │   └── plugin/
 │       ├── cli-action.ts

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,11 +14,7 @@ export default [
             'dist/**',
             'node_modules/**',
             'coverage/**',
-            'src/mockContracts/testForge/**',
-            // Mock contract fixtures ship as plain JS alongside their .ts
-            // counterparts; they're not part of the TS project.
-            'src/mockContracts/test/*.js',
-            'src/mockContracts/scripts/*.js'
+            'src/mockContracts/testForge/**'
         ]
     },
     js.configs.recommended,

--- a/src/buildMockContracts.ts
+++ b/src/buildMockContracts.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url'
 
 import MockContractsList from './mockContracts/index.ts'
 import detectPackage from './packageInstaller.ts'
+import { transformTsToJs } from './utils.ts'
 import type { IMockContractsList } from './types.ts'
 
 /**
@@ -62,12 +63,33 @@ const buildMockContract = async (contractName: string) => {
     }
 }
 
+/**
+ * Pick the file extension that matches the consumer project's Hardhat config.
+ *
+ * Templates ship as TypeScript (the single source of truth, see #159). When
+ * the consumer uses `hardhat.config.js` we still want to write a `.js` file,
+ * so the JS variant is generated from the TS template at write time.
+ */
+const pickArtifactExtension = (): 'ts' | 'js' => {
+    if (fs.existsSync('hardhat.config.ts')) return 'ts'
+    if (fs.existsSync('hardhat.config.js')) return 'js'
+    // No Hardhat config present — fall back to TS, which is the canonical
+    // template language and what Hardhat 3 expects.
+    return 'ts'
+}
+
+const swapExtension = (filePath: string, target: 'ts' | 'js' | 'sol'): string => {
+    if (target === 'ts') return filePath.replace(/\.js$/, '.ts')
+    if (target === 'sol') return filePath
+    return filePath.replace(/\.ts$/, '.js')
+}
+
 export const buildMockDeploymentScriptOrTest = async (contractName: string, type: string) => {
     const packageRootPath = resolveMockContractsPath()
     if (!packageRootPath) return
     if (!MockContractsList) return
 
-    let deploymentScriptOrTestPath: string = ''
+    let templatePath: string = ''
     let finalPath: string = ''
     let scriptOrTestDir: string = ''
     const contractToMock: IMockContractsList[] = MockContractsList.filter(
@@ -77,36 +99,26 @@ export const buildMockDeploymentScriptOrTest = async (contractName: string, type
 
     if (type === 'deployment') {
         scriptOrTestDir = 'scripts'
-        if (fs.existsSync('hardhat.config.js')) {
-            if (contractToMock[0].deploymentScriptJs !== undefined)
-                deploymentScriptOrTestPath = contractToMock[0].deploymentScriptJs
-        } else if (fs.existsSync('hardhat.config.ts')) {
-            if (contractToMock[0].deploymentScriptTs !== undefined)
-                deploymentScriptOrTestPath = contractToMock[0].deploymentScriptTs
-            else if (contractToMock[0].deploymentScriptJs !== undefined)
-                deploymentScriptOrTestPath = contractToMock[0].deploymentScriptJs
-        }
-        finalPath = deploymentScriptOrTestPath
+        if (contractToMock[0].deploymentScript === undefined) return
+        templatePath = contractToMock[0].deploymentScript
     } else if (type === 'test') {
         scriptOrTestDir = 'test'
-        if (fs.existsSync('hardhat.config.js')) {
-            if (contractToMock[0].testScriptJs !== undefined)
-                deploymentScriptOrTestPath = contractToMock[0].testScriptJs
-        } else if (fs.existsSync('hardhat.config.ts')) {
-            if (contractToMock[0].testScriptTs !== undefined)
-                deploymentScriptOrTestPath = contractToMock[0].testScriptTs
-            else if (contractToMock[0].testScriptJs !== undefined)
-                deploymentScriptOrTestPath = contractToMock[0].testScriptJs
-        }
-        finalPath = deploymentScriptOrTestPath
+        if (contractToMock[0].testScript === undefined) return
+        templatePath = contractToMock[0].testScript
     } else if (type === 'testForge') {
         scriptOrTestDir = 'contracts/test'
-        if (contractToMock[0]?.testContractFoundry !== undefined)
-            deploymentScriptOrTestPath = contractToMock[0].testContractFoundry
-        finalPath = deploymentScriptOrTestPath.replace('testForge/', 'contracts/test/')
+        if (contractToMock[0]?.testContractFoundry === undefined) return
+        templatePath = contractToMock[0].testContractFoundry
+        finalPath = templatePath.replace('testForge/', 'contracts/test/')
     }
 
-    if (!deploymentScriptOrTestPath || !finalPath) return
+    if (!templatePath) return
+
+    const targetExtension = pickArtifactExtension()
+    // Foundry test contracts are Solidity (`.sol`) — never affected by the
+    // TS/JS choice. Everything else follows the user's Hardhat config.
+    const writeExtension: 'ts' | 'js' | 'sol' = type === 'testForge' ? 'sol' : targetExtension
+    finalPath = swapExtension(finalPath || templatePath, writeExtension)
 
     // Ensure the destination directory exists before writing. `recursive: true`
     // is a no-op when the directory is already there, so this is safe to run
@@ -120,8 +132,9 @@ export const buildMockDeploymentScriptOrTest = async (contractName: string, type
     }
 
     console.log('\x1b[32m%s\x1b[0m', 'Creating ' + type + ' for ', contractName, ' in ' + scriptOrTestDir + '/')
-    const rawData: any = fs.readFileSync(path.join(packageRootPath, deploymentScriptOrTestPath))
-    fs.writeFileSync(finalPath, rawData)
+    const rawData: string = fs.readFileSync(path.join(packageRootPath, templatePath), 'utf8')
+    const rendered = writeExtension === 'js' ? transformTsToJs(rawData) : rawData
+    fs.writeFileSync(finalPath, rendered)
 }
 
 export default buildMockContract

--- a/src/mockContracts/index.ts
+++ b/src/mockContracts/index.ts
@@ -5,30 +5,24 @@ const MockContractsList: IMockContractsList[] = [
         name: 'MockERC20',
         desc: 'Basic ERC20 Token contract.',
         dependencies: ['@openzeppelin/contracts'],
-        deploymentScriptJs: 'scripts/deploy-Mock-ERC20.js',
-        deploymentScriptTs: 'scripts/deploy-Mock-ERC20.ts',
-        testScriptJs: 'test/test-Mock-ERC20.js',
-        testScriptTs: 'test/test-Mock-ERC20.ts',
+        deploymentScript: 'scripts/deploy-Mock-ERC20.ts',
+        testScript: 'test/test-Mock-ERC20.ts',
         testContractFoundry: 'testForge/MockERC20.t.sol'
     },
     {
         name: 'MockERC721',
         desc: 'Basic ERC721 NFT Token contract (unique nft).',
         dependencies: ['@openzeppelin/contracts'],
-        deploymentScriptJs: 'scripts/deploy-Mock-ERC721.js',
-        deploymentScriptTs: 'scripts/deploy-Mock-ERC721.ts',
-        testScriptJs: 'test/test-Mock-ERC721.js',
-        testScriptTs: 'test/test-Mock-ERC721.ts',
+        deploymentScript: 'scripts/deploy-Mock-ERC721.ts',
+        testScript: 'test/test-Mock-ERC721.ts',
         testContractFoundry: 'testForge/MockERC721.t.sol'
     },
     {
         name: 'MockERC1155',
         desc: 'Basic ERC1155 NFT Token contract (multiple nfts).',
         dependencies: ['@openzeppelin/contracts'],
-        deploymentScriptJs: 'scripts/deploy-Mock-ERC1155.js',
-        deploymentScriptTs: 'scripts/deploy-Mock-ERC1155.ts',
-        testScriptJs: 'test/test-Mock-ERC1155.js',
-        testScriptTs: 'test/test-Mock-ERC1155.ts',
+        deploymentScript: 'scripts/deploy-Mock-ERC1155.ts',
+        testScript: 'test/test-Mock-ERC1155.ts',
         testContractFoundry: 'testForge/MockERC1155.t.sol'
     },
     // Upgradeable contracts
@@ -36,10 +30,8 @@ const MockContractsList: IMockContractsList[] = [
         name: 'MockERC20Upgradeable',
         desc: 'Basic Upgradeable ERC20 Token contract.',
         dependencies: ['@openzeppelin/contracts-upgradeable'],
-        deploymentScriptJs: 'scripts/deploy-Mock-ERC20Upgradeable.js',
-        deploymentScriptTs: 'scripts/deploy-Mock-ERC20Upgradeable.ts',
-        testScriptJs: 'test/test-Mock-ERC20Upgradeable.js',
-        testScriptTs: 'test/test-Mock-ERC20Upgradeable.ts',
+        deploymentScript: 'scripts/deploy-Mock-ERC20Upgradeable.ts',
+        testScript: 'test/test-Mock-ERC20Upgradeable.ts',
         testContractFoundry: 'testForge/MockERC20Upgradeable.t.sol',
         upgradeable: true
     },
@@ -47,10 +39,8 @@ const MockContractsList: IMockContractsList[] = [
         name: 'MockERC721Upgradeable',
         desc: 'Basic Upgradeable ERC721 NFT Token contract (unique nft).',
         dependencies: ['@openzeppelin/contracts-upgradeable'],
-        deploymentScriptJs: 'scripts/deploy-Mock-ERC721Upgradeable.js',
-        deploymentScriptTs: 'scripts/deploy-Mock-ERC721Upgradeable.ts',
-        testScriptJs: 'test/test-Mock-ERC721Upgradeable.js',
-        testScriptTs: 'test/test-Mock-ERC721Upgradeable.ts',
+        deploymentScript: 'scripts/deploy-Mock-ERC721Upgradeable.ts',
+        testScript: 'test/test-Mock-ERC721Upgradeable.ts',
         testContractFoundry: 'testForge/MockERC721Upgradeable.t.sol',
         upgradeable: true
     },
@@ -58,10 +48,8 @@ const MockContractsList: IMockContractsList[] = [
         name: 'MockERC1155Upgradeable',
         desc: 'Basic Upgradeable ERC1155 NFT Token contract (multiple nfts).',
         dependencies: ['@openzeppelin/contracts-upgradeable'],
-        deploymentScriptJs: 'scripts/deploy-Mock-ERC1155Upgradeable.js',
-        deploymentScriptTs: 'scripts/deploy-Mock-ERC1155Upgradeable.ts',
-        testScriptJs: 'test/test-Mock-ERC1155Upgradeable.js',
-        testScriptTs: 'test/test-Mock-ERC1155Upgradeable.ts',
+        deploymentScript: 'scripts/deploy-Mock-ERC1155Upgradeable.ts',
+        testScript: 'test/test-Mock-ERC1155Upgradeable.ts',
         testContractFoundry: 'testForge/MockERC1155Upgradeable.t.sol',
         upgradeable: true
     },
@@ -69,15 +57,13 @@ const MockContractsList: IMockContractsList[] = [
         name: 'MockProxyAdmin',
         desc: 'Setup a Mock Proxy Admin contract to interact with the Proxy contract.',
         dependencies: ['@openzeppelin/contracts'],
-        deploymentScriptJs: 'scripts/deploy-Mock-Proxy-Admin.js',
-        deploymentScriptTs: 'scripts/deploy-Mock-Proxy-Admin.ts'
+        deploymentScript: 'scripts/deploy-Mock-Proxy-Admin.ts'
     },
     {
         name: 'MockTransparentUpgradeableProxy',
         desc: 'Setup a Mock Transparent Upgradeable Proxy contract to implement your contract logic using delegatecall.',
         dependencies: ['@openzeppelin/contracts'],
-        deploymentScriptJs: 'scripts/deploy-Mock-Transparent-Upgradeable-Proxy.js',
-        deploymentScriptTs: 'scripts/deploy-Mock-Transparent-Upgradeable-Proxy.ts'
+        deploymentScript: 'scripts/deploy-Mock-Transparent-Upgradeable-Proxy.ts'
     }
 ]
 

--- a/src/serveInquirer.ts
+++ b/src/serveInquirer.ts
@@ -662,23 +662,14 @@ const serveMockContractCreatorSelector = async () => {
                     : MockContractsList.filter((file: IMockContractsList) => file.name === mockContractFirstSelected)
             const subject = mockContractsSelectedDetail.length > 1 ? 'these mock contracts' : 'this mock contract'
             const mockContractDetailSelector = []
-            if (
-                mockContractsSelectedDetail.some(
-                    (file: IMockContractsList) =>
-                        file.deploymentScriptJs !== undefined || file.deploymentScriptTs !== undefined
-                )
-            )
+            if (mockContractsSelectedDetail.some((file: IMockContractsList) => file.deploymentScript !== undefined))
                 mockContractDetailSelector.push({
                     type: 'list',
                     name: 'mockDeploymentScript',
                     message: 'Create a deployment script for ' + subject,
                     choices: ['yes', 'no']
                 })
-            if (
-                mockContractsSelectedDetail.some(
-                    (file: IMockContractsList) => file.testScriptJs !== undefined || file.testScriptTs !== undefined
-                )
-            )
+            if (mockContractsSelectedDetail.some((file: IMockContractsList) => file.testScript !== undefined))
                 mockContractDetailSelector.push({
                     type: 'list',
                     name: 'mockTestScript',

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,10 +24,11 @@ export interface IMockContractsList {
     name: string
     desc: string
     dependencies: string[]
-    deploymentScriptJs?: string
-    deploymentScriptTs?: string
-    testScriptJs?: string
-    testScriptTs?: string
+    // The single TS template path. When the consumer project uses a JS
+    // `hardhat.config`, the JS output is generated from this template on
+    // the fly (see `transformTsToJs` in utils.ts).
+    deploymentScript: string
+    testScript?: string
     testContractFoundry?: string
     upgradeable?: boolean
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -170,3 +170,56 @@ export const waitForReadability = (ms?: number): Promise<void> => {
     const effective = Math.min(Math.max(ms ?? DEFAULT_READABILITY_PAUSE_MS, 0), 5000)
     return sleep(effective).then(() => undefined)
 }
+
+/**
+ * Convert a mock-contract template written in TypeScript into the equivalent
+ * CommonJS JavaScript that ships alongside `hardhat.config.js` projects.
+ *
+ * The mock template language is small and well-controlled:
+ * - `import { a, b } from 'mod'` becomes `const { a, b } = require('mod')`
+ * - `// @ts-ignore-next-line` directives are dropped (they only exist to
+ *   silence the TS compiler over the `hardhat` module).
+ * - `: any` type annotations on `let`/`const` declarations are stripped.
+ * - `main().catch(...)` is rewritten so the script also exits cleanly on
+ *   success, matching the original hand-maintained JS templates.
+ *
+ * This keeps a single source of truth (`src/mockContracts/scripts/*.ts` and
+ * `src/mockContracts/test/*.ts`) while still serving `hardhat.config.js`
+ * consumers the language they prefer (closes #159).
+ */
+export const transformTsToJs = (source: string): string => {
+    const lines = source.split('\n')
+    const out: string[] = []
+    for (const line of lines) {
+        // Drop `// @ts-ignore-next-line` directives — they only exist to
+        // silence the TS compiler over the `hardhat` module.
+        if (/^\s*\/\/\s*@ts-ignore-next-line\s*$/.test(line)) continue
+
+        // `import { a, b } from 'mod'` → `const { a, b } = require('mod')`.
+        // We only consume the named-import form these templates use.
+        const importMatch = line.match(/^(\s*)import\s*\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]\s*$/)
+        if (importMatch) {
+            const indent = importMatch[1]
+            const names = importMatch[2]
+                .split(',')
+                .map((name) => name.trim())
+                .filter((name) => name.length > 0)
+            out.push(`${indent}const { ${names.join(', ')} } = require('${importMatch[3]}')`)
+            continue
+        }
+
+        // Strip `: any` type annotations on top-level `let`/`const`/`var`
+        // declarations. The mock templates only use `: any`, no other types.
+        const anyAnnotation = line.replace(/^(\s*(?:let|const|var)\s+[A-Za-z_$][\w$]*)\s*:\s*any\b/, '$1')
+        out.push(anyAnnotation)
+    }
+
+    let js = out.join('\n')
+
+    // Ensure the script exits cleanly on success. The TS templates use
+    // `main().catch(...)` with `process.exitCode = 1`; the JS-equivalent
+    // generated file needs an explicit `process.exit(0)` on success.
+    js = js.replace(/main\(\)\s*\.catch\s*\(/, 'main()\n    .then(() => process.exit(0))\n    .catch(')
+
+    return js
+}

--- a/test/buildMockContracts.test.ts
+++ b/test/buildMockContracts.test.ts
@@ -152,4 +152,50 @@ describe('buildMockContracts (issue #168)', function () {
             expect(fs.existsSync('test/test-Mock-ERC20.ts')).to.equal(true)
         })
     })
+
+    // Issue #159: the mock template language ships as a single TS source
+    // of truth. When the consumer project uses `hardhat.config.js`, the JS
+    // variant is generated from the TS template on the fly.
+    describe('JS output for hardhat.config.js projects (issue #159)', function () {
+        beforeEach(function () {
+            // Replace the TS config with a JS one for this describe block.
+            fs.rmSync('hardhat.config.ts')
+            fs.writeFileSync('hardhat.config.js', 'module.exports = {}\n')
+        })
+
+        it('writes a CommonJS deployment script', async function () {
+            await buildMockContract('MockERC20')
+            await buildMockDeploymentScriptOrTest('MockERC20', 'deployment')
+
+            expect(fs.existsSync('scripts/deploy-Mock-ERC20.js')).to.equal(true)
+            expect(fs.existsSync('scripts/deploy-Mock-ERC20.ts')).to.equal(false)
+            const generated = fs.readFileSync('scripts/deploy-Mock-ERC20.js', 'utf8')
+            expect(generated).to.contain("const { addressBook, ethers, network } = require('hardhat')")
+            expect(generated).to.not.match(/@ts-ignore-next-line/)
+            expect(generated).to.contain('.then(() => process.exit(0))')
+        })
+
+        it('writes a CommonJS test script', async function () {
+            await buildMockContract('MockERC20')
+            await buildMockDeploymentScriptOrTest('MockERC20', 'test')
+
+            expect(fs.existsSync('test/test-Mock-ERC20.js')).to.equal(true)
+            expect(fs.existsSync('test/test-Mock-ERC20.ts')).to.equal(false)
+            const generated = fs.readFileSync('test/test-Mock-ERC20.js', 'utf8')
+            expect(generated).to.contain("const { expect } = require('chai')")
+            expect(generated).to.contain("const { ethers } = require('hardhat')")
+            expect(generated).to.not.match(/:\s*any/)
+        })
+
+        it('does not overwrite an existing JS deployment script', async function () {
+            fs.mkdirSync('scripts')
+            const existing = path.join('scripts', 'deploy-Mock-ERC20.js')
+            fs.writeFileSync(existing, '// user edits')
+
+            await buildMockContract('MockERC20')
+            await buildMockDeploymentScriptOrTest('MockERC20', 'deployment')
+
+            expect(fs.readFileSync(existing, 'utf8')).to.equal('// user edits')
+        })
+    })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 
-import { runCommand, sleep, waitForReadability } from '../src/utils.ts'
+import { runCommand, sleep, transformTsToJs, waitForReadability } from '../src/utils.ts'
 
 describe('Command runner', function () {
     it('runCommand resolves once the child process exits', async function () {
@@ -102,5 +102,66 @@ describe('waitForReadability', function () {
         const start = Date.now()
         await waitForReadability(0)
         expect(Date.now() - start).to.be.lessThan(20)
+    })
+})
+
+describe('transformTsToJs', function () {
+    it('rewrites named imports into the equivalent CommonJS require', function () {
+        const ts = [
+            "// @ts-ignore-next-line",
+            "import { addressBook, ethers, network } from 'hardhat'",
+            "import { expect } from 'chai'",
+            '',
+            'async function main() {',
+            '    const [deployer] = await ethers.getSigners()',
+            '}',
+            '',
+            'main().catch((error) => {',
+            '    console.error(error)',
+            '    process.exitCode = 1',
+            '})'
+        ].join('\n')
+
+        const js = transformTsToJs(ts)
+
+        expect(js).to.not.match(/@ts-ignore-next-line/)
+        expect(js).to.contain("const { addressBook, ethers, network } = require('hardhat')")
+        expect(js).to.contain("const { expect } = require('chai')")
+        expect(js).to.not.match(/^\s*import\s/m)
+    })
+
+    it('strips `: any` type annotations from top-level declarations', function () {
+        const ts = ['import { ethers } from \'hardhat\'', '', 'let mockERC20: any', 'let deployer: any'].join('\n')
+        const js = transformTsToJs(ts)
+        expect(js).to.not.match(/:\s*any/)
+        expect(js).to.contain('let mockERC20')
+        expect(js).to.contain('let deployer')
+    })
+
+    it('rewrites main().catch(...) so the script exits cleanly on success', function () {
+        const ts = [
+            "import { ethers } from 'hardhat'",
+            '',
+            'async function main() {}',
+            '',
+            'main().catch((error) => {',
+            '    console.error(error)',
+            '    process.exitCode = 1',
+            '})'
+        ].join('\n')
+
+        const js = transformTsToJs(ts)
+
+        expect(js).to.contain('.then(() => process.exit(0))')
+        expect(js).to.contain('.catch(')
+    })
+
+    it('produces valid CommonJS that requires the same module specifiers', function () {
+        const ts = ["import { expect } from 'chai'", '', 'expect(1).to.equal(1)'].join('\n')
+        const js = transformTsToJs(ts)
+        // The transformed output should still reference the same module
+        // name (`chai`) and the same imported symbol (`expect`).
+        expect(js).to.contain("require('chai')")
+        expect(js).to.contain('expect(1).to.equal(1)')
     })
 })


### PR DESCRIPTION
## Summary

The mock-contract creator used to ship parallel `.ts` and `.js` files for every deployment script and test under `src/mockContracts/`. Keeping the two in sync was error-prone — at least one JS file had already drifted from its TS counterpart (`deploy-Mock-Transparent-Upgradeable-Proxy.js` was missing the `hre.` prefix on one of the `addressBook` calls).

Switch to a single TypeScript source of truth, and generate the CommonJS variant on the fly when the consumer project uses `hardhat.config.js`. The end-user experience is unchanged.

## Changes

- **`src/utils.ts`** — new `transformTsToJs` helper that rewrites the TS template into the equivalent CommonJS. It only handles the patterns the mock templates actually use (`import { ... } from 'mod'`, `// @ts-ignore-next-line`, `: any` annotations, `main().catch(...)`).
- **`src/mockContracts/scripts/`** & **`src/mockContracts/test/`** — drop the 15 `.js` files; keep the `.ts` files as the single source of truth.
- **`src/types.ts`** — collapse `IMockContractsList.{deploymentScriptJs, deploymentScriptTs, testScriptJs, testScriptTs}` into a single `deploymentScript` and `testScript` field. The JS-vs-TS extension is decided at write time.
- **`src/buildMockContracts.ts`** — pick the file extension by inspecting the consumer project's `hardhat.config`. When the JS path is chosen, run the template through `transformTsToJs` before writing.
- **`src/serveInquirer.ts`** — menu filter no longer has to choose between `deploymentScriptJs` / `deploymentScriptTs`; it just checks for `deploymentScript` / `testScript`.
- **`eslint.config.js`** — drop the now-stale ignore for `src/mockContracts/{scripts,test}/*.js`.
- **`test/utils.test.ts`** — unit tests for `transformTsToJs` (imports, `: any`, `main().catch(...)`, module specifiers).
- **`test/buildMockContracts.test.ts`** — new describe block that exercises the `hardhat.config.js` path and asserts the generated file is valid CommonJS (no `@ts-ignore-next-line`, no `: any`, exits cleanly on success).
- **`README.md`** — call out the single source of truth in the mock-contracts menu docs and the directory tree.

## Acceptance criteria for #159

- [x] One source of truth per mock script/test
- [x] CLI still offers the language(s) users need
- [x] README mock section updated

## Verification

```
$ npm test
  92 passing (771ms)

$ npm run lint
(clean)
```

Closes #159