### PR TITLE
docs: align README install docs with Hardhat 3 plugins array API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,31 @@ Or with Yarn
 yarn add hardhat-awesome-cli
 ```
 
-### 2. Import/Require this package in your hardhat.config.js/.ts
+### 2. Add the plugin to your `hardhat.config.ts`
 
-Inside inside hardhat.config.js
+> **Heads up:** Hardhat 3 dropped side-effect plugin registration. The
+> `require('hardhat-awesome-cli')` / `import 'hardhat-awesome-cli'` style from
+> Hardhat 2 no longer works — the plugin must be added to the `plugins` array
+> of `defineConfig(...)`.
 
-```js
-require('hardhat-awesome-cli')
+Add the plugin to the `plugins` array, importing the plugin entry exposed by
+the package under the `/plugin` subpath:
+
+```ts
+import { defineConfig } from 'hardhat/config'
+import hardhatAwesomeCli from 'hardhat-awesome-cli/plugin'
+
+export default defineConfig({
+    plugins: [hardhatAwesomeCli],
+})
 ```
 
-or inside hardhat.config.ts (Typescript)
-
-```js
-import 'hardhat-awesome-cli'
-```
+> **Which import path?**
+>
+> - `hardhat-awesome-cli/plugin` — the Hardhat 3 plugin (use this in
+>   `hardhat.config.ts`).
+> - `hardhat-awesome-cli` — the standalone CLI binary (`npx hardhat-awesome-cli`
+>   for running outside a Hardhat project). Not a plugin entry.
 
 ### Other option
 
@@ -65,6 +77,18 @@ in the hardhat project, you want to use this plugin
 
 ```bash
 npm link hardhat-awesome-cli
+```
+
+then in your `hardhat.config.ts`, import the plugin from the `/plugin` subpath
+the same way as for the published package:
+
+```ts
+import { defineConfig } from 'hardhat/config'
+import hardhatAwesomeCli from 'hardhat-awesome-cli/plugin'
+
+export default defineConfig({
+    plugins: [hardhatAwesomeCli],
+})
 ```
 
 </details>


### PR DESCRIPTION
Closes #152

## Summary
- Replace the Hardhat 2-style side-effect registration snippets (`require('hardhat-awesome-cli')` / `import 'hardhat-awesome-cli'`) with the Hardhat 3 `plugins: [...]` array pattern already used in `test/hardhat-cli/hardhat.config.ts`.
- Clarify the two package entry points:
  - `hardhat-awesome-cli/plugin` — the Hardhat 3 plugin (used in `hardhat.config.ts`)
  - `hardhat-awesome-cli` — the standalone CLI binary
- Update the symlink / local-dev section to import the plugin via the `/plugin` subpath, matching the published package API.

## Acceptance criteria
- [x] Install section shows Hardhat 3 `plugins: [...]` setup
- [x] Clarify package export path (`hardhat-awesome-cli` vs `hardhat-awesome-cli/plugin`)
- [x] Symlink / local-dev instructions still work with the new API

## Verification
- `npm run lint` passes
- `npm test` passes (92/92)
- README diff is docs-only (single file)