### PR TITLE
fix: refresh the Hardhat plugin list and register plugins the Hardhat 3 way

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,35 @@ export default defineConfig({
     -   Exclude script file from the scripts selection list
     -   Exclude script or contract file from the contract selection list
     -   Install/Uninstall other Hardhat plugins
+
+        The plugin list targets Hardhat 3: the CLI installs the package with
+        npm/yarn, adds `import <plugin> from '<package>'` to your
+        `hardhat.config`, and registers it in the `plugins` array of
+        `defineConfig(...)` (Hardhat 3 dropped side-effect plugin registration).
+
+          <details>
+              <summary>Plugins offered</summary>
+
+        - `@nomicfoundation/hardhat-toolbox-mocha-ethers` / `@nomicfoundation/hardhat-toolbox-viem`
+        - `@nomicfoundation/hardhat-ethers` / `@nomicfoundation/hardhat-ethers-chai-matchers`
+        - `@nomicfoundation/hardhat-viem` / `@nomicfoundation/hardhat-viem-assertions`
+        - `@nomicfoundation/hardhat-verify` (contract verification, replaces `@nomiclabs/hardhat-etherscan`)
+        - `@nomicfoundation/hardhat-network-helpers`
+        - `@nomicfoundation/hardhat-ignition-ethers` / `@nomicfoundation/hardhat-ignition-viem`
+        - `@nomicfoundation/hardhat-keystore`
+        - `@nomicfoundation/hardhat-typechain`
+        - `@nomicfoundation/hardhat-mocha` / `@nomicfoundation/hardhat-node-test-runner`
+        - `@nomicfoundation/hardhat-ledger`
+        - `@nomicfoundation/hardhat-foundry`
+
+        The Hardhat 2 era `@nomiclabs/*` packages (waffle, ganache, solpp,
+        web3, …) do not load under Hardhat 3, so they are no longer offered
+        for installation. They still show up in the uninstall menu — labelled
+        `(Hardhat 2 only)` — so a project migrating to Hardhat 3 can drop them
+        from both `package.json` and `hardhat.config`.
+
+          </details>
+
     -   Create Github test workflows (for NPM and/or Yarn and for Hardhat test&coverage and/or Foundry test)
     -   Create Foundry settings, remapping and test utilities
           <details>
@@ -206,7 +235,7 @@ In 'More settings' you can also add a custom chain, create an issue or pull requ
 When a menu selection maps to one of the CLI flags above (add/remove Hardhat plugins, add/remove activated chains, create GitHub workflows, install Foundry settings, install the Foundry test utility, …), the CLI prints the equivalent `npx hardhat cli --<flag> <value>` command line after the change is applied. This lets you skip the interactive prompts next time around, or wire the same action into a CI script.
 
 ```commandline
-Equivalent CLI command:  npx hardhat cli --addHardhatPlugin @nomiclabs/hardhat-ethers
+Equivalent CLI command:  npx hardhat cli --addHardhatPlugin @nomicfoundation/hardhat-ethers
 ```
 
 Boolean flags (no value) are rendered without an argument:

--- a/src/config.ts
+++ b/src/config.ts
@@ -144,61 +144,168 @@ export const DefaultChainList: IChain[] = [
     }
 ]
 
+/**
+ * Plugins offered by the "Add other Hardhat plugins" menu.
+ *
+ * Every entry here installs and loads under Hardhat 3: it ships a
+ * `HardhatPlugin` as its default export and is registered through the
+ * `plugins` array of `defineConfig(...)`. The Hardhat 2 era `@nomiclabs/*`
+ * packages moved to `LegacyHardhatPluginsList` — they are no longer offered
+ * for installation, only for removal.
+ */
 export const DefaultHardhatPluginsList: IHardhatPluginAvailableList[] = [
+    {
+        title: 'Hardhat Toolbox (Mocha + Ethers)',
+        name: '@nomicfoundation/hardhat-toolbox-mocha-ethers',
+        addInHardhatConfig: true
+    },
+    {
+        title: 'Hardhat Toolbox (node:test + Viem)',
+        name: '@nomicfoundation/hardhat-toolbox-viem',
+        addInHardhatConfig: true
+    },
+    {
+        title: 'Hardhat Ethers',
+        name: '@nomicfoundation/hardhat-ethers',
+        addInHardhatConfig: true
+    },
+    {
+        title: 'Hardhat Ethers Chai matchers',
+        name: '@nomicfoundation/hardhat-ethers-chai-matchers',
+        addInHardhatConfig: true
+    },
+    {
+        title: 'Hardhat Viem',
+        name: '@nomicfoundation/hardhat-viem',
+        addInHardhatConfig: true
+    },
+    {
+        title: 'Hardhat Viem assertions',
+        name: '@nomicfoundation/hardhat-viem-assertions',
+        addInHardhatConfig: true
+    },
+    {
+        title: 'Hardhat Verify (contract verification, replaces hardhat-etherscan)',
+        name: '@nomicfoundation/hardhat-verify',
+        addInHardhatConfig: true
+    },
+    {
+        title: 'Hardhat Network helpers',
+        name: '@nomicfoundation/hardhat-network-helpers',
+        addInHardhatConfig: true
+    },
+    {
+        title: 'Hardhat Ignition (Ethers)',
+        name: '@nomicfoundation/hardhat-ignition-ethers',
+        addInHardhatConfig: true
+    },
+    {
+        title: 'Hardhat Ignition (Viem)',
+        name: '@nomicfoundation/hardhat-ignition-viem',
+        addInHardhatConfig: true
+    },
+    {
+        title: 'Hardhat Keystore (encrypted secrets)',
+        name: '@nomicfoundation/hardhat-keystore',
+        addInHardhatConfig: true
+    },
+    {
+        title: 'Hardhat Typechain',
+        name: '@nomicfoundation/hardhat-typechain',
+        addInHardhatConfig: true
+    },
+    {
+        title: 'Hardhat Mocha test runner',
+        name: '@nomicfoundation/hardhat-mocha',
+        addInHardhatConfig: true
+    },
+    {
+        title: 'Hardhat node:test test runner',
+        name: '@nomicfoundation/hardhat-node-test-runner',
+        addInHardhatConfig: true
+    },
+    {
+        title: 'Hardhat Foundry',
+        name: '@nomicfoundation/hardhat-foundry',
+        addInHardhatConfig: true
+    }
+]
+
+/**
+ * Hardhat 2 only plugins. They do not load under Hardhat 3 — either because
+ * the package was renamed (`@nomiclabs/hardhat-etherscan` became
+ * `@nomicfoundation/hardhat-verify`), superseded (Hardhat 3 has a built-in
+ * network and test runners), or simply unmaintained (waffle, ganache, solpp).
+ *
+ * They are kept out of the install menu but still listed by the uninstall
+ * menu, so a project migrating from Hardhat 2 can clean them up from the CLI.
+ */
+export const LegacyHardhatPluginsList: IHardhatPluginAvailableList[] = [
     {
         title: 'Hardhat ethers',
         name: '@nomiclabs/hardhat-ethers',
-        addInHardhatConfig: true
+        addInHardhatConfig: true,
+        hardhat2Only: true
     },
     {
         title: 'Hardhat waffle',
         name: '@nomiclabs/hardhat-waffle',
-        addInHardhatConfig: true
+        addInHardhatConfig: true,
+        hardhat2Only: true
     },
     {
         title: 'Solidity coverage',
         name: 'solidity-coverage',
-        addInHardhatConfig: true
+        addInHardhatConfig: true,
+        hardhat2Only: true
     },
     {
         title: 'Hardhat etherscan',
         name: '@nomiclabs/hardhat-etherscan',
-        addInHardhatConfig: true
+        addInHardhatConfig: true,
+        hardhat2Only: true
     },
     {
         title: 'Hardhat web3',
         name: '@nomiclabs/hardhat-web3',
-        addInHardhatConfig: true
+        addInHardhatConfig: true,
+        hardhat2Only: true
     },
     {
         title: 'Hardhat solhint',
         name: '@nomiclabs/hardhat-solhint',
-        addInHardhatConfig: true
+        addInHardhatConfig: true,
+        hardhat2Only: true
     },
     {
         title: 'Hardhat gas reporter',
         name: 'hardhat-gas-reporter',
-        addInHardhatConfig: true
+        addInHardhatConfig: true,
+        hardhat2Only: true
     },
     {
         title: 'Hardhat contract sizer',
         name: 'hardhat-contract-sizer',
-        addInHardhatConfig: true
+        addInHardhatConfig: true,
+        hardhat2Only: true
     },
     {
         title: 'Hardhat Ganache',
         name: '@nomiclabs/hardhat-ganache',
-        addInHardhatConfig: true
+        addInHardhatConfig: true,
+        hardhat2Only: true
     },
     {
         title: 'Hardhat solpp',
         name: '@nomiclabs/hardhat-solpp',
-        addInHardhatConfig: true
+        addInHardhatConfig: true,
+        hardhat2Only: true
     },
     {
         title: 'Hardhat Vyper',
         name: '@nomiclabs/hardhat-vyper',
-        addInHardhatConfig: true
+        addInHardhatConfig: true,
+        hardhat2Only: true
     }
 ]
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -225,6 +225,11 @@ export const DefaultHardhatPluginsList: IHardhatPluginAvailableList[] = [
         addInHardhatConfig: true
     },
     {
+        title: 'Hardhat Ledger (hardware wallet signer)',
+        name: '@nomicfoundation/hardhat-ledger',
+        addInHardhatConfig: true
+    },
+    {
         title: 'Hardhat Foundry',
         name: '@nomicfoundation/hardhat-foundry',
         addInHardhatConfig: true

--- a/src/packageInstaller.ts
+++ b/src/packageInstaller.ts
@@ -3,176 +3,266 @@ import path from 'path'
 
 import { runCommand } from './utils.ts'
 
+/**
+ * Derive the local identifier used to import a plugin into `hardhat.config`.
+ *
+ * Every Hardhat 3 plugin exposes its `HardhatPlugin` object as the module
+ * **default** export, so the identifier is ours to choose. We derive it from
+ * the package name (scope stripped, camel cased) so the same package always
+ * maps to the same identifier — that makes the "already added?" check and the
+ * removal path deterministic, and it works for packages the user passes to
+ * `--addHardhatPlugin` that are not in `DefaultHardhatPluginsList`.
+ *
+ * `@nomicfoundation/hardhat-ethers` -> `hardhatEthers`
+ * `@nomicfoundation/hardhat-toolbox-mocha-ethers` -> `hardhatToolboxMochaEthers`
+ */
+export const hardhatPluginImportName = (packageName: string): string => {
+    const bareName = packageName.split('/').filter(Boolean).pop() ?? packageName
+    const camelCased = bareName.replace(/[^A-Za-z0-9]+(.)?/g, (_match, nextChar) =>
+        nextChar ? nextChar.toUpperCase() : ''
+    )
+    // A package such as `3rd-party-plugin` would produce an identifier starting
+    // with a digit, which is not valid JavaScript.
+    return /^[A-Za-z_$]/.test(camelCased) ? camelCased : `plugin${camelCased}`
+}
+
+/**
+ * Hardhat 3 config files register plugins through the `plugins` array of
+ * `defineConfig({ ... })` instead of the Hardhat 2 side-effect
+ * `require('some-plugin')` / `import 'some-plugin'`.
+ */
+export const isHardhat3Config = (hardhatConfigFile: string): boolean =>
+    /\bdefineConfig\s*\(/.test(hardhatConfigFile) || /\bplugins\s*:\s*\[/.test(hardhatConfigFile)
+
+const importsPackage = (hardhatConfigFile: string, packageName: string): boolean =>
+    new RegExp(`from\\s*['"]${escapeForRegExp(packageName)}['"]`).test(hardhatConfigFile)
+
+const escapeForRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+/**
+ * Split the content of an array literal on its top-level commas only, so an
+ * entry such as `somePlugin({ a: 1, b: 2 })` stays in one piece.
+ */
+const splitTopLevelEntries = (arrayContent: string): string[] => {
+    const entries: string[] = []
+    let depth = 0
+    let current = ''
+    let quote: string | null = null
+    for (const char of arrayContent) {
+        if (quote) {
+            current += char
+            if (char === quote) quote = null
+            continue
+        }
+        if (char === '"' || char === "'" || char === '`') {
+            quote = char
+            current += char
+            continue
+        }
+        if (char === '(' || char === '[' || char === '{') depth++
+        if (char === ')' || char === ']' || char === '}') depth--
+        if (char === ',' && depth === 0) {
+            entries.push(current)
+            current = ''
+            continue
+        }
+        current += char
+    }
+    entries.push(current)
+    return entries
+}
+
+/**
+ * Locate the `plugins: [ ... ]` array of the config file and return the index
+ * boundaries of its content, or `undefined` when there is no such array.
+ */
+const findPluginsArray = (hardhatConfigFile: string): { start: number; end: number } | undefined => {
+    const match = hardhatConfigFile.match(/\bplugins\s*:\s*\[/)
+    if (match === null || match.index === undefined) return undefined
+    const start = match.index + match[0].length
+    let depth = 1
+    for (let index = start; index < hardhatConfigFile.length; index++) {
+        const char = hardhatConfigFile[index]
+        if (char === '[') depth++
+        else if (char === ']') {
+            depth--
+            if (depth === 0) return { start, end: index }
+        }
+    }
+    return undefined
+}
+
+/**
+ * Rewrite the content of the `plugins` array, preserving the existing layout
+ * (single line vs one entry per line, trailing comma or not).
+ */
+const renderPluginsArray = (arrayContent: string, entries: string[]): string => {
+    if (entries.length === 0) return ''
+    const isMultiline = arrayContent.includes('\n')
+    if (!isMultiline) return entries.join(', ')
+
+    const indentMatch = arrayContent.match(/\n([ \t]*)\S/)
+    const entryIndent = indentMatch ? indentMatch[1] : '        '
+    const closingIndentMatch = arrayContent.match(/\n([ \t]*)$/)
+    const closingIndent = closingIndentMatch ? closingIndentMatch[1] : entryIndent.slice(0, -4)
+    const trailingComma = /,\s*$/.test(arrayContent) ? ',' : ''
+    return `\n${entries.map((entry) => `${entryIndent}${entry}`).join(',\n')}${trailingComma}\n${closingIndent}`
+}
+
+const insertImportStatement = (hardhatConfigFile: string, packageName: string, importName: string): string => {
+    const importStatement = `import ${importName} from '${packageName}'`
+    const importStatements = [...hardhatConfigFile.matchAll(/^import\s[^\n]*\n/gm)]
+    if (importStatements.length === 0) return `${importStatement}\n${hardhatConfigFile}`
+    const lastImport = importStatements[importStatements.length - 1]
+    const insertAt = (lastImport.index ?? 0) + lastImport[0].length
+    return `${hardhatConfigFile.slice(0, insertAt)}${importStatement}\n${hardhatConfigFile.slice(insertAt)}`
+}
+
+/**
+ * Add a plugin to a Hardhat 3 config file: import its default export and push
+ * that identifier into the `plugins` array of `defineConfig(...)`.
+ *
+ * Returns the new file content, or `undefined` when the config could not be
+ * updated safely (no `plugins` array to extend) so the caller can tell the
+ * user what to add by hand instead of writing a broken config.
+ */
+export const addPluginToHardhat3Config = (hardhatConfigFile: string, packageName: string): string | undefined => {
+    const importName = hardhatPluginImportName(packageName)
+    const pluginsArray = findPluginsArray(hardhatConfigFile)
+    if (pluginsArray === undefined) return undefined
+
+    const arrayContent = hardhatConfigFile.slice(pluginsArray.start, pluginsArray.end)
+    const entries = splitTopLevelEntries(arrayContent)
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0)
+    if (entries.includes(importName) && importsPackage(hardhatConfigFile, packageName)) return hardhatConfigFile
+
+    if (!entries.includes(importName)) entries.push(importName)
+    const withPlugin =
+        hardhatConfigFile.slice(0, pluginsArray.start) +
+        renderPluginsArray(arrayContent, entries) +
+        hardhatConfigFile.slice(pluginsArray.end)
+
+    if (importsPackage(withPlugin, packageName)) return withPlugin
+    return insertImportStatement(withPlugin, packageName, importName)
+}
+
+/**
+ * Remove a plugin from a Hardhat 3 config file: drop its entry from the
+ * `plugins` array and delete the import statement that fed it.
+ */
+export const removePluginFromHardhat3Config = (hardhatConfigFile: string, packageName: string): string => {
+    const importName = hardhatPluginImportName(packageName)
+    let newHardhatConfig = hardhatConfigFile
+
+    const pluginsArray = findPluginsArray(newHardhatConfig)
+    if (pluginsArray !== undefined) {
+        const arrayContent = newHardhatConfig.slice(pluginsArray.start, pluginsArray.end)
+        const entries = splitTopLevelEntries(arrayContent)
+            .map((entry) => entry.trim())
+            .filter((entry) => entry.length > 0 && entry !== importName)
+        newHardhatConfig =
+            newHardhatConfig.slice(0, pluginsArray.start) +
+            renderPluginsArray(arrayContent, entries) +
+            newHardhatConfig.slice(pluginsArray.end)
+    }
+
+    // Drop the import line, whatever local name it was bound to.
+    return newHardhatConfig.replace(
+        new RegExp(`^import\\s[^\\n]*from\\s*['"]${escapeForRegExp(packageName)}['"];?[ \\t]*\\r?\\n`, 'm'),
+        ''
+    )
+}
+
+/**
+ * Hardhat 2 style registration, kept for projects that have not migrated yet:
+ * the plugin is loaded for its side effects next to the `hardhat-awesome-cli`
+ * import.
+ */
+const addPluginToHardhat2Config = (hardhatConfigFile: string, packageName: string): string | undefined => {
+    const anchors = [
+        `require("hardhat-awesome-cli")`,
+        `require('hardhat-awesome-cli')`,
+        `import "hardhat-awesome-cli"`,
+        `import 'hardhat-awesome-cli'`
+    ]
+    const anchor = anchors.find((candidate) => hardhatConfigFile.includes(candidate))
+    if (anchor === undefined) return undefined
+    const statement = anchor.replace('hardhat-awesome-cli', packageName)
+    return hardhatConfigFile.replace(anchor, `${anchor}\n${statement}`)
+}
+
+const removePluginFromHardhat2Config = (hardhatConfigFile: string, packageName: string): string =>
+    hardhatConfigFile.replace(
+        new RegExp(
+            `^[ \\t]*(?:require|import)\\s*\\(?\\s*['"]${escapeForRegExp(packageName)}['"]\\s*\\)?;?[ \\t]*\\r?\\n`,
+            'm'
+        ),
+        ''
+    )
+
+const isPluginRegistered = (hardhatConfigFile: string, packageName: string): boolean => {
+    const quoted = escapeForRegExp(packageName)
+    return new RegExp(`(?:require|import|from)\\s*\\(?\\s*['"]${quoted}['"]`).test(hardhatConfigFile)
+}
+
+export const findHardhatConfigFilePath = (): string => {
+    if (fs.existsSync('hardhat.config.ts')) return 'hardhat.config.ts'
+    if (fs.existsSync('hardhat.config.js')) return 'hardhat.config.js'
+    if (fs.existsSync('hardhat.config.mjs')) return 'hardhat.config.mjs'
+    if (fs.existsSync('hardhat.config.cjs')) return 'hardhat.config.cjs'
+    return ''
+}
+
 const importPackageHardhatConfigFile = async (packageName: string, addToConfig: boolean, removeFromConfig: boolean) => {
-    let hardhatConfigFilePath: string = ''
-    if (fs.existsSync('hardhat.config.js')) hardhatConfigFilePath = 'hardhat.config.js'
-    else if (fs.existsSync('hardhat.config.ts')) hardhatConfigFilePath = 'hardhat.config.ts'
-    else {
+    const hardhatConfigFilePath = findHardhatConfigFilePath()
+    if (!hardhatConfigFilePath) {
         console.log('\x1b[31m%s\x1b[0m', 'Hardhat config file not found!')
         return
     }
-    if (hardhatConfigFilePath) {
-        const rawdata: any = fs.readFileSync(hardhatConfigFilePath)
-        const hardhatConfigFile = rawdata.toString()
-        if (
-            addToConfig &&
-            hardhatConfigFile.search(`require("${packageName}");`) === -1 &&
-            hardhatConfigFile.search(`require('${packageName}');`) === -1 &&
-            hardhatConfigFile.search(`require("${packageName}")`) === -1 &&
-            hardhatConfigFile.search(`require('${packageName}')`) === -1 &&
-            hardhatConfigFile.search(`import "${packageName}";`) === -1 &&
-            hardhatConfigFile.search(`import '${packageName}';`) === -1 &&
-            hardhatConfigFile.search(`import "${packageName}"`) === -1 &&
-            hardhatConfigFile.search(`import '${packageName}'`) === -1
-        ) {
-            let newHardHatConfig: string = ''
-            if (hardhatConfigFile.includes(`require("hardhat-awesome-cli");`)) {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'Adding ' + packageName + ' from your ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile.replace(
-                    `require("hardhat-awesome-cli");`,
-                    `require("hardhat-awesome-cli");
-require("${packageName}");`
-                )
-            } else if (hardhatConfigFile.includes(`require('hardhat-awesome-cli');`)) {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'Adding ' + packageName + ' from your ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile.replace(
-                    `require('hardhat-awesome-cli');`,
-                    `require('hardhat-awesome-cli');
-require('${packageName}');`
-                )
-            } else if (hardhatConfigFile.includes(`require("hardhat-awesome-cli")`)) {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'Adding ' + packageName + ' from your ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile.replace(
-                    `require("hardhat-awesome-cli")`,
-                    `require("hardhat-awesome-cli")
-require("${packageName}")`
-                )
-            } else if (hardhatConfigFile.includes(`require('hardhat-awesome-cli')`)) {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'Adding ' + packageName + ' from your ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile.replace(
-                    `require('hardhat-awesome-cli')`,
-                    `require('hardhat-awesome-cli')
-require('${packageName}')`
-                )
-            } else if (hardhatConfigFile.includes(`import "hardhat-awesome-cli";`)) {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'Adding ' + packageName + ' from your ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile.replace(
-                    `import "hardhat-awesome-cli";`,
-                    `import "hardhat-awesome-cli";
-import "${packageName}";`
-                )
-            } else if (hardhatConfigFile.includes(`import 'hardhat-awesome-cli';`)) {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'Adding ' + packageName + ' from your ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile.replace(
-                    `import 'hardhat-awesome-cli';')`,
-                    `import 'hardhat-awesome-cli';
-import '${packageName}';`
-                )
-            } else if (hardhatConfigFile.includes(`import "hardhat-awesome-cli"`)) {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'Adding ' + packageName + ' from your ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile.replace(
-                    `import "hardhat-awesome-cli"`,
-                    `import "hardhat-awesome-cli"
-import "${packageName}"`
-                )
-            } else if (hardhatConfigFile.includes(`import 'hardhat-awesome-cli'`)) {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'Adding ' + packageName + ' from your ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile.replace(
-                    `import 'hardhat-awesome-cli'`,
-                    `import 'hardhat-awesome-cli'
-import '${packageName}'`
-                )
-            } else {
-                newHardHatConfig = hardhatConfigFile
-                console.log(
-                    '\x1b[34m%s\x1b[0m',
-                    'Package ' + packageName + ' not imported in ' + hardhatConfigFilePath + ' file'
-                )
-            }
-            fs.writeFileSync(hardhatConfigFilePath, newHardHatConfig)
-        } else if (removeFromConfig) {
-            let newHardHatConfig: string = ''
-            if (hardhatConfigFile.search(`require("${packageName}");`)) {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'Removing ' + packageName + ' from your ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile.replace(`require("${packageName}");`, '')
-            } else if (hardhatConfigFile.search(`require('${packageName}');`)) {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'Removing ' + packageName + ' from your ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile.replace(`require('${packageName}');`, '')
-            } else if (hardhatConfigFile.search(`require("${packageName}")`)) {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'Removing ' + packageName + ' from your ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile.replace(`require("${packageName}")`, '')
-            } else if (hardhatConfigFile.search(`require('${packageName}')`)) {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'Removing ' + packageName + ' from your ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile.replace(`require('${packageName}')`, '')
-            } else if (hardhatConfigFile.search(`import "${packageName}";`)) {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'Removing ' + packageName + ' from your ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile.replace(`import "${packageName}";`, '')
-            } else if (hardhatConfigFile.search(`import '${packageName}';`)) {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'Removing ' + packageName + ' from your ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile.replace(`import '${packageName}';`, '')
-            } else if (hardhatConfigFile.search(`import "${packageName}"`)) {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'Removing ' + packageName + ' from your ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile.replace(`import "${packageName}"`, '')
-            } else if (hardhatConfigFile.search(`import '${packageName}'`)) {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'Removing ' + packageName + ' from your ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile.replace(`import '${packageName}'`, '')
-            } else {
-                console.log(
-                    '\x1b[34m%s\x1b[0m',
-                    'Package ' + packageName + ' not found in ' + hardhatConfigFilePath + ' file'
-                )
-                newHardHatConfig = hardhatConfigFile
-            }
-            fs.writeFileSync(hardhatConfigFilePath, newHardHatConfig)
+    const hardhatConfigFile = fs.readFileSync(hardhatConfigFilePath, 'utf8')
+    const hardhat3 = isHardhat3Config(hardhatConfigFile)
+
+    if (addToConfig) {
+        if (isPluginRegistered(hardhatConfigFile, packageName)) {
+            console.log(
+                '\x1b[34m%s\x1b[0m',
+                'Package ' + packageName + ' is already registered in ' + hardhatConfigFilePath
+            )
+            return
         }
+        const newHardhatConfig = hardhat3
+            ? addPluginToHardhat3Config(hardhatConfigFile, packageName)
+            : addPluginToHardhat2Config(hardhatConfigFile, packageName)
+        if (newHardhatConfig === undefined) {
+            console.log(
+                '\x1b[31m%s\x1b[0m',
+                'Could not update ' + hardhatConfigFilePath + ' automatically, please add it yourself:'
+            )
+            if (hardhat3)
+                console.log(
+                    '\x1b[97m%s\x1b[0m',
+                    `import ${hardhatPluginImportName(packageName)} from '${packageName}'\n` +
+                        `... defineConfig({ plugins: [${hardhatPluginImportName(packageName)}] })`
+                )
+            else console.log('\x1b[97m%s\x1b[0m', `require('${packageName}')`)
+            return
+        }
+        console.log('\x1b[33m%s\x1b[0m', 'Adding ' + packageName + ' to your ' + hardhatConfigFilePath + ' file')
+        fs.writeFileSync(hardhatConfigFilePath, newHardhatConfig)
+        return
+    }
+
+    if (removeFromConfig) {
+        if (!isPluginRegistered(hardhatConfigFile, packageName)) {
+            console.log('\x1b[34m%s\x1b[0m', 'Package ' + packageName + ' not found in ' + hardhatConfigFilePath)
+            return
+        }
+        console.log('\x1b[33m%s\x1b[0m', 'Removing ' + packageName + ' from your ' + hardhatConfigFilePath + ' file')
+        const newHardhatConfig = hardhat3
+            ? removePluginFromHardhat3Config(hardhatConfigFile, packageName)
+            : removePluginFromHardhat2Config(hardhatConfigFile, packageName)
+        fs.writeFileSync(hardhatConfigFilePath, newHardhatConfig)
     }
 }
 

--- a/src/serveInquirer.ts
+++ b/src/serveInquirer.ts
@@ -26,6 +26,7 @@ import {
     DefaultGithubWorkflowsGroup,
     DefaultGithubWorkflowsList,
     DefaultHardhatPluginsList,
+    LegacyHardhatPluginsList,
     getAddressBookConfig
 } from './config.ts'
 import MockContractsList from './mockContracts/index.ts'
@@ -586,9 +587,9 @@ const servePackageInstaller = async () => {
             }
         ])
         .then(async (pluginssSelected: { plugins: string }) => {
-            DefaultHardhatPluginsList.map(async (plugin: IHardhatPluginAvailableList) => {
-                if (plugin.title === pluginssSelected.plugins) packageToInstall = plugin
-            })
+            packageToInstall = DefaultHardhatPluginsList.find(
+                (plugin: IHardhatPluginAvailableList) => plugin.title === pluginssSelected.plugins
+            )
         })
     if (packageToInstall !== undefined) {
         await detectPackage(packageToInstall.name, true, false, packageToInstall.addInHardhatConfig)
@@ -598,10 +599,15 @@ const servePackageInstaller = async () => {
 }
 
 const servePackageUninstaller = async () => {
+    // Projects migrating from Hardhat 2 still have `@nomiclabs/*` packages
+    // installed, so the uninstall menu covers the legacy list too even though
+    // those plugins are no longer offered for installation.
+    const uninstallableList: IHardhatPluginAvailableList[] = [...DefaultHardhatPluginsList, ...LegacyHardhatPluginsList]
     const hardhatPluginInstalled: string[] = (
         await Promise.all(
-            DefaultHardhatPluginsList.map(async (plugin: IHardhatPluginAvailableList) => {
-                if (await detectPackage(plugin.name, false, false, false)) return plugin.title
+            uninstallableList.map(async (plugin: IHardhatPluginAvailableList) => {
+                if (await detectPackage(plugin.name, false, false, false))
+                    return plugin.hardhat2Only ? `${plugin.title} (Hardhat 2 only)` : plugin.title
                 return null
             })
         )
@@ -612,14 +618,16 @@ const servePackageUninstaller = async () => {
             {
                 type: 'list',
                 name: 'plugins',
-                message: 'Select a plugin to install',
+                message: 'Select a plugin to uninstall',
                 choices: hardhatPluginInstalled
             }
         ])
         .then(async (pluginssSelected: { plugins: string }) => {
-            DefaultHardhatPluginsList.map(async (plugin: IHardhatPluginAvailableList) => {
-                if (plugin.title === pluginssSelected.plugins) packageToUninstall = plugin
-            })
+            packageToUninstall = uninstallableList.find(
+                (plugin: IHardhatPluginAvailableList) =>
+                    (plugin.hardhat2Only ? `${plugin.title} (Hardhat 2 only)` : plugin.title) ===
+                    pluginssSelected.plugins
+            )
         })
     if (packageToUninstall !== undefined) {
         await detectPackage(packageToUninstall.name, false, true, packageToUninstall.addInHardhatConfig)

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,11 @@ export interface IHardhatPluginAvailableList {
     title: string
     name: string
     addInHardhatConfig: boolean
+    /**
+     * Hardhat 2 era package that does not load under Hardhat 3. These are not
+     * offered for installation, only for removal (see `LegacyHardhatPluginsList`).
+     */
+    hardhat2Only?: boolean
 }
 
 export interface IFileList {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -38,8 +38,8 @@ describe('Command builder', function () {
 
 describe('Final CLI command builder', function () {
     it('builds a single-flag command with one value', function () {
-        expect(buildFinalCliCommand('addHardhatPlugin', '@nomiclabs/hardhat-ethers')).to.equal(
-            'npx hardhat cli --addHardhatPlugin @nomiclabs/hardhat-ethers'
+        expect(buildFinalCliCommand('addHardhatPlugin', '@nomicfoundation/hardhat-ethers')).to.equal(
+            'npx hardhat cli --addHardhatPlugin @nomicfoundation/hardhat-ethers'
         )
     })
 

--- a/test/packageInstaller.test.ts
+++ b/test/packageInstaller.test.ts
@@ -1,0 +1,203 @@
+import { expect } from 'chai'
+import { execFileSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { DefaultHardhatPluginsList, LegacyHardhatPluginsList } from '../src/config.ts'
+import {
+    addPluginToHardhat3Config,
+    findHardhatConfigFilePath,
+    hardhatPluginImportName,
+    isHardhat3Config,
+    removePluginFromHardhat3Config
+} from '../src/packageInstaller.ts'
+import type { IHardhatPluginAvailableList } from '../src/types.ts'
+
+const HARDHAT_3_CONFIG = `import { defineConfig } from 'hardhat/config'
+import hardhatAwesomeCli from 'hardhat-awesome-cli/plugin'
+
+export default defineConfig({
+    plugins: [hardhatAwesomeCli],
+    solidity: '0.8.28'
+})
+`
+
+const HARDHAT_3_CONFIG_MULTILINE = `import { defineConfig } from 'hardhat/config'
+import hardhatAwesomeCli from 'hardhat-awesome-cli/plugin'
+
+export default defineConfig({
+    plugins: [
+        hardhatAwesomeCli
+    ]
+})
+`
+
+const HARDHAT_2_CONFIG = `require('hardhat-awesome-cli')
+
+module.exports = {
+    solidity: '0.8.28'
+}
+`
+
+describe('packageInstaller', function () {
+    describe('hardhatPluginImportName', function () {
+        it('camel cases the package name and strips the scope', function () {
+            expect(hardhatPluginImportName('@nomicfoundation/hardhat-ethers')).to.equal('hardhatEthers')
+            expect(hardhatPluginImportName('@nomicfoundation/hardhat-toolbox-mocha-ethers')).to.equal(
+                'hardhatToolboxMochaEthers'
+            )
+            expect(hardhatPluginImportName('hardhat-gas-reporter')).to.equal('hardhatGasReporter')
+        })
+
+        it('never produces an identifier starting with a digit', function () {
+            expect(hardhatPluginImportName('3rd-party-plugin')).to.equal('plugin3rdPartyPlugin')
+        })
+    })
+
+    describe('isHardhat3Config', function () {
+        it('detects a defineConfig based config', function () {
+            expect(isHardhat3Config(HARDHAT_3_CONFIG)).to.equal(true)
+        })
+
+        it('does not flag a Hardhat 2 module.exports config', function () {
+            expect(isHardhat3Config(HARDHAT_2_CONFIG)).to.equal(false)
+        })
+    })
+
+    describe('addPluginToHardhat3Config', function () {
+        it('imports the plugin default export and appends it to the plugins array', function () {
+            const updated = addPluginToHardhat3Config(HARDHAT_3_CONFIG, '@nomicfoundation/hardhat-ethers')
+
+            expect(updated).to.include(`import hardhatEthers from '@nomicfoundation/hardhat-ethers'`)
+            expect(updated).to.include('plugins: [hardhatAwesomeCli, hardhatEthers]')
+            // The rest of the config is untouched
+            expect(updated).to.include(`solidity: '0.8.28'`)
+        })
+
+        it('preserves a multi line plugins array layout', function () {
+            const updated = addPluginToHardhat3Config(HARDHAT_3_CONFIG_MULTILINE, '@nomicfoundation/hardhat-verify')
+
+            expect(updated).to.include('plugins: [\n        hardhatAwesomeCli,\n        hardhatVerify\n    ]')
+        })
+
+        it('fills an empty plugins array', function () {
+            const source = `import { defineConfig } from 'hardhat/config'\n\nexport default defineConfig({\n    plugins: []\n})\n`
+
+            const updated = addPluginToHardhat3Config(source, '@nomicfoundation/hardhat-keystore')
+
+            expect(updated).to.include('plugins: [hardhatKeystore]')
+            expect(updated).to.include(`import hardhatKeystore from '@nomicfoundation/hardhat-keystore'`)
+        })
+
+        it('is a no-op when the plugin is already registered', function () {
+            const once = addPluginToHardhat3Config(HARDHAT_3_CONFIG, '@nomicfoundation/hardhat-ethers') as string
+
+            expect(addPluginToHardhat3Config(once, '@nomicfoundation/hardhat-ethers')).to.equal(once)
+        })
+
+        it('returns undefined instead of corrupting a config without a plugins array', function () {
+            const source = `import { defineConfig } from 'hardhat/config'\n\nexport default defineConfig({\n    solidity: '0.8.28'\n})\n`
+
+            expect(addPluginToHardhat3Config(source, '@nomicfoundation/hardhat-ethers')).to.equal(undefined)
+        })
+
+        it('keeps entries that are function calls in one piece', function () {
+            const source = `import { defineConfig } from 'hardhat/config'\nimport somePlugin from 'some-plugin'\n\nexport default defineConfig({\n    plugins: [somePlugin({ a: 1, b: 2 })]\n})\n`
+
+            const updated = addPluginToHardhat3Config(source, '@nomicfoundation/hardhat-viem')
+
+            expect(updated).to.include('plugins: [somePlugin({ a: 1, b: 2 }), hardhatViem]')
+        })
+    })
+
+    describe('removePluginFromHardhat3Config', function () {
+        it('removes both the plugins array entry and the import statement', function () {
+            const withPlugin = addPluginToHardhat3Config(HARDHAT_3_CONFIG, '@nomicfoundation/hardhat-ethers') as string
+
+            const removed = removePluginFromHardhat3Config(withPlugin, '@nomicfoundation/hardhat-ethers')
+
+            expect(removed).to.equal(HARDHAT_3_CONFIG)
+        })
+
+        it('leaves the config untouched when the plugin is not registered', function () {
+            expect(removePluginFromHardhat3Config(HARDHAT_3_CONFIG, '@nomicfoundation/hardhat-verify')).to.equal(
+                HARDHAT_3_CONFIG
+            )
+        })
+
+        it('empties the plugins array when the last plugin is removed', function () {
+            const source = `import { defineConfig } from 'hardhat/config'\nimport hardhatViem from '@nomicfoundation/hardhat-viem'\n\nexport default defineConfig({\n    plugins: [hardhatViem]\n})\n`
+
+            const removed = removePluginFromHardhat3Config(source, '@nomicfoundation/hardhat-viem')
+
+            expect(removed).to.include('plugins: []')
+            expect(removed).to.not.include('@nomicfoundation/hardhat-viem')
+        })
+    })
+
+    describe('findHardhatConfigFilePath', function () {
+        const initialCwd = process.cwd()
+        let fixtureDirectory: string
+
+        beforeEach(function () {
+            fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-installer-'))
+            process.chdir(fixtureDirectory)
+        })
+
+        afterEach(function () {
+            process.chdir(initialCwd)
+            fs.rmSync(fixtureDirectory, { recursive: true, force: true })
+        })
+
+        it('prefers the TypeScript config', function () {
+            fs.writeFileSync('hardhat.config.ts', HARDHAT_3_CONFIG)
+            fs.writeFileSync('hardhat.config.js', HARDHAT_2_CONFIG)
+
+            expect(findHardhatConfigFilePath()).to.equal('hardhat.config.ts')
+        })
+
+        it('returns an empty string when no config exists', function () {
+            expect(findHardhatConfigFilePath()).to.equal('')
+        })
+
+        it('produces a syntactically valid config for every plugin offered', function () {
+            for (const plugin of DefaultHardhatPluginsList) {
+                const updated = addPluginToHardhat3Config(HARDHAT_3_CONFIG, plugin.name) as string
+                const configPath = path.join(fixtureDirectory, 'generated.mjs')
+                fs.writeFileSync(configPath, updated)
+
+                // `node --check` parses the module without executing it, so an
+                // invalid splice (broken import, dangling comma, ...) fails here.
+                expect(() => execFileSync(process.execPath, ['--check', configPath]), plugin.name).to.not.throw()
+            }
+        })
+    })
+
+    describe('DefaultHardhatPluginsList', function () {
+        it('only offers Hardhat 3 compatible plugins', function () {
+            for (const plugin of DefaultHardhatPluginsList) {
+                expect(plugin.hardhat2Only, `${plugin.name} should not be flagged Hardhat 2 only`).to.not.equal(true)
+                expect(plugin.name, `${plugin.name} is a Hardhat 2 era package`).to.not.match(/^@nomiclabs\//)
+            }
+        })
+
+        it('does not overlap with the legacy list', function () {
+            const legacyNames = LegacyHardhatPluginsList.map((plugin: IHardhatPluginAvailableList) => plugin.name)
+
+            for (const plugin of DefaultHardhatPluginsList) expect(legacyNames).to.not.include(plugin.name)
+        })
+
+        it('maps every plugin to a unique config import identifier', function () {
+            const importNames = DefaultHardhatPluginsList.map((plugin: IHardhatPluginAvailableList) =>
+                hardhatPluginImportName(plugin.name)
+            )
+
+            expect(new Set(importNames).size).to.equal(importNames.length)
+        })
+
+        it('flags every legacy plugin as Hardhat 2 only', function () {
+            for (const plugin of LegacyHardhatPluginsList) expect(plugin.hardhat2Only).to.equal(true)
+        })
+    })
+})


### PR DESCRIPTION
Closes #153

## Problem

`DefaultHardhatPluginsList` still offered the Hardhat 2 era `@nomiclabs/*` packages (ethers, waffle, etherscan, web3, solhint, ganache, solpp, vyper) plus `solidity-coverage`, `hardhat-gas-reporter` and `hardhat-contract-sizer`. None of them load under Hardhat 3 — the scope was retired, some were renamed (`etherscan` → `verify`), and the rest are unmaintained.

Worse, the injection path was also Hardhat 2 only: installing a plugin spliced a side-effect `require('plugin')` next to the `hardhat-awesome-cli` import. Hardhat 3 ignores that entirely — a plugin is only loaded when its default export is listed in the `plugins` array of `defineConfig(...)`. So "Add other Hardhat plugins" installed the package and left the project without it registered.

## Changes

**Plugin list (`src/config.ts`)** — `DefaultHardhatPluginsList` now only contains packages whose current release declares `hardhat: ^3` as a peer dependency and exports a `HardhatPlugin` as its default export:

both toolboxes, `hardhat-ethers` / `hardhat-ethers-chai-matchers`, `hardhat-viem` / `hardhat-viem-assertions`, `hardhat-verify`, `hardhat-network-helpers`, `hardhat-ignition-ethers` / `-viem`, `hardhat-keystore`, `hardhat-typechain`, `hardhat-mocha` / `hardhat-node-test-runner`, `hardhat-ledger` and `hardhat-foundry`.

The old entries move to a new `LegacyHardhatPluginsList`, flagged `hardhat2Only`. They are no longer installable, but the **uninstall** menu still lists them (labelled `(Hardhat 2 only)`) so a project migrating to Hardhat 3 can drop them from `package.json` and `hardhat.config` with the same flow.

**Config injection (`src/packageInstaller.ts`)** — `importPackageHardhatConfigFile` detects the config style and, for Hardhat 3, imports the plugin default export under a name derived from the package (`@nomicfoundation/hardhat-ethers` → `hardhatEthers`) and appends that identifier to the `plugins` array:

```diff
 import { defineConfig } from 'hardhat/config'
 import hardhatAwesomeCli from 'hardhat-awesome-cli/plugin'
+import hardhatVerify from '@nomicfoundation/hardhat-verify'

 export default defineConfig({
-    plugins: [hardhatAwesomeCli],
+    plugins: [hardhatAwesomeCli, hardhatVerify],
 })
```

The existing layout is preserved (single-line arrays stay on one line, multi-line arrays keep their indentation and trailing-comma style, entries that are call expressions are not split apart), and removal is the exact inverse so add/remove round-trips back to the original file byte for byte. When there is no `plugins` array to extend, the CLI prints the two lines to add by hand rather than writing a config it cannot update safely.

This is deliberately a scoped, well-tested string transformation — the full AST-based rewrite stays with #158.

Two bugs fixed along the way:

- the removal path tested `String.search(...)` for truthiness, which returns `-1` (truthy) when the pattern is absent, so the first branch always ran and the "not found in config" message was unreachable;
- the uninstall prompt asked the user to "Select a plugin to **install**", and both menus resolved the selected entry with `Array.map(async ...)` instead of `Array.find`.

## Verification

- `npm test` — 112 passing (92 before; 20 new in `test/packageInstaller.test.ts`)
- `npm run lint` — clean
- New tests cover the identifier derivation, config-style detection, add/remove/round-trip, layout preservation, the refuse-to-corrupt path, and a guard that no offered plugin is a `@nomiclabs/*` package
- One test writes the generated config for **every** plugin in the list and runs `node --check` on it, so a bad splice fails the suite
- Package names, `hardhat: ^3.8.0` peer dependencies and the `export default <HardhatPlugin>` shape were each verified against the published tarballs on npm
- `npm run build` still reports the same pre-existing `tsc` errors as `main` (`NetworkManager.name`, `paths.cli`) — unchanged by this PR

## Follow-up spotted, not fixed here

"Run coverage tests" shells out to `npx hardhat coverage`, a task that only exists with `solidity-coverage` under Hardhat 2. Hardhat 3 ships coverage natively as `hardhat test --coverage`, and gas reporting as `hardhat test --gas-stats`. The `DefaultGithubWorkflowsList` entries that require `solidity-coverage` have the same problem. Worth its own issue.