### PR TITLE
fix: drop stale sleep() comments and guard against future regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,23 @@ Boolean flags (no value) are rendered without an argument:
 Equivalent CLI command:  npx hardhat cli --addFoundry
 ```
 
+### Skipping or shortening UI pauses
+
+The CLI uses two environment variables to control the brief readability pauses that sit between menu steps:
+
+-   `AWESOME_CLI_NO_PAUSE=1` — skip every short pause entirely. Recommended in CI or any non-interactive run where the menu would otherwise redraw over the previous output.
+-   `AWESOME_CLI_PAUSE_MS=<ms>` — set the default pause length (default `250`, capped at `5000`). Useful when you want a quicker menu without disabling pauses outright.
+
+```commandline
+# Quiet CI run — never pause, never block on a sleep
+AWESOME_CLI_NO_PAUSE=1 npx hardhat cli --addHardhatPlugin @nomicfoundation/hardhat-ethers
+
+# Speed up a local session — keep pauses, but cut them in half
+AWESOME_CLI_PAUSE_MS=120 npx hardhat cli
+```
+
+Long-running work (running tests, installing or removing a plugin, flattening a contract, …) does **not** rely on these variables — it already awaits the child process exit, so the menu never resumes before the command has finished.
+
 ## Helper tools
 
 Tools that you can use in your scripts and tests to make your life easier

--- a/src/buildNetworks.ts
+++ b/src/buildNetworks.ts
@@ -90,7 +90,6 @@ export const buildActivatedChainNetworkConfig = () => {
                 }
                 return chainConfig
             })
-            // await sleep(100)
             const fihainConfig = `${chainConfig.slice(0, -1)}`
             return fihainConfig
         }

--- a/src/serveInquirer.ts
+++ b/src/serveInquirer.ts
@@ -561,8 +561,10 @@ const servePackageInstaller = async () => {
             return plugin.title
         }
     )
-    // Resolve every detection up-front: previously this used `Array.map(async)`
-    // and a `sleep(500)` to mask the race between the spawned probes and the
+    // Probe every plugin in parallel and wait for each detection to finish
+    // before reading the result, so the menu sees a consistent snapshot of
+    // what is installed. Previously this used `Array.map(async)` and a
+    // `sleep(500)` to mask the race between the spawned probes and the
     // subsequent read, which was both slow and flaky.
     const hardhatPluginInstalled: string[] = (
         await Promise.all(

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,68 @@
 import { expect } from 'chai'
+import fs from 'fs'
+import path from 'path'
 
 import { runCommand, sleep, transformTsToJs, waitForReadability } from '../src/utils.ts'
+
+const SRC_DIR = path.resolve(__dirname, '..', 'src')
+
+/**
+ * Walk `src/` and return every TypeScript source file. The guard tests below
+ * scan each file for fixed-duration `sleep(N)` calls; we mirror that intent
+ * here so a future file under a different name still gets checked.
+ */
+const listSourceFiles = (directory: string): string[] => {
+    const entries = fs.readdirSync(directory, { withFileTypes: true })
+    const files: string[] = []
+    for (const entry of entries) {
+        const fullPath = path.join(directory, entry.name)
+        if (entry.isDirectory()) {
+            if (entry.name === 'node_modules' || entry.name === 'dist') continue
+            files.push(...listSourceFiles(fullPath))
+        } else if (entry.isFile() && /\.(ts|tsx)$/.test(entry.name) && !/\.test\.ts$/.test(entry.name)) {
+            files.push(fullPath)
+        }
+    }
+    return files
+}
+
+/**
+ * Source-level guard for issue #157: prevent a regression of the fixed
+ * `sleep(5000)` style "wait long enough and hope" pattern. Any multi-second
+ * `sleep(N)` call shows up in `details` so the failure points at the exact
+ * offending line(s).
+ *
+ * The single matching `sleep(...)` site is the legacy `sleep = setTimeout(...)`
+ * helper itself (`src/utils.ts`); everything else should use `waitForReadability`
+ * for human-facing pauses and `await runCommand` for child-process completion.
+ */
+describe('no mandatory multi-second sleeps in src/', function () {
+    it('does not call sleep(N) with N >= 1000 anywhere in src/', function () {
+        const offenders: { file: string; line: number; text: string }[] = []
+        // `sleep\s*\(\s*([0-9]+)\s*\)` would miss `sleep (1000)` so tolerate
+        // optional whitespace; capture the literal numeric duration.
+        const sleepCallRegex = /\bsleep\s*\(\s*([0-9]+)\s*\)/
+        for (const file of listSourceFiles(SRC_DIR)) {
+            const lines = fs.readFileSync(file, 'utf8').split('\n')
+            for (let index = 0; index < lines.length; index++) {
+                const line = lines[index]
+                // Skip the legacy helper itself (`src/utils.ts` defines
+                // `export const sleep = (ms: number) => …`).
+                if (/export\s+const\s+sleep\s*=/.test(line)) continue
+                // Permit the doc / changelog comments that *mention* sleep
+                // in prose — only enforce on lines that actually look like
+                // a call site (no leading whitespace-`//`).
+                if (/^\s*\/\//.test(line)) continue
+                const match = line.match(sleepCallRegex)
+                if (match === null) continue
+                const duration = Number(match[1])
+                if (duration >= 1000) offenders.push({ file, line: index + 1, text: line.trim() })
+            }
+        }
+
+        expect(offenders, JSON.stringify(offenders, null, 2)).to.deep.equal([])
+    })
+})
 
 describe('Command runner', function () {
     it('runCommand resolves once the child process exits', async function () {


### PR DESCRIPTION
Closes #157

The bulk of the work called out in #157 (replacing `sleep(5000)` with
`runCommand` that resolves on child exit, and routing human-facing
pauses through a short, configurable `waitForReadability`) had already
landed on main. This PR closes the loop on the remaining loose ends.

## Changes

### Cleanup (`ed9d246`)
- `src/buildNetworks.ts`: drop a leftover commented-out `// await sleep(100)` that was dead code.
- `src/serveInquirer.ts`: rewrite the paragraph that opened with "previously this used `Array.map(async)` and a `sleep(500)` ...", which read as if the workaround was still in place. The new comment describes what the code does today and only mentions the old `sleep(500)` once for context.

### Test (`bb3e7f9`)
- `test/utils.test.ts`: source-level guard that fails if any future `sleep(N)` call with `N >= 1000` is reintroduced in `src/`. The legacy `sleep = setTimeout(...)` helper and prose mentions in comments are whitelisted.

### Docs (`4503b16`)
- `README.md`: short subsection between "Equivalent CLI command" and "Helper tools" documenting `AWESOME_CLI_NO_PAUSE=1` and `AWESOME_CLI_PAUSE_MS`, with a note that long-running work doesn't depend on either.

## Acceptance criteria from #157

- [x] No mandatory multi-second sleeps on the happy path — confirmed by the new guard test (`npm test` → 113 passing).
- [x] Commands still finish before the next menu step — already covered by the existing `runCommand` implementation; nothing in this PR changes the menu flow.

## Verification

```
npm test   # 113 passing
npm run lint   # clean
```