### PR TITLE
ci: add consumer smoke test (npm pack + install into HH3 fixture)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,21 @@ jobs:
         run: npm ci
       - name: Run test
         run: npm run test
+
+  smoke:
+    name: Smoke test (consumer install)
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      - name: NPM Clean Install
+        run: npm ci
+      - name: Run consumer smoke test
+        # Packs the package, installs it into a clean HH3 fixture under
+        # test/fixtures/smoke, and asserts the `cli` task loads. Catches
+        # regressions where the published layout (exports map, plugin entry,
+        # hook handlers) is no longer consumable by a fresh Hardhat project.
+        run: npm run smoke

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,11 @@ export default [
             'dist/**',
             'node_modules/**',
             'coverage/**',
-            'src/mockContracts/testForge/**'
+            'src/mockContracts/testForge/**',
+            // The smoke fixture is a self-contained HH3 consumer project
+            // (imports the plugin from its published subpath). It's parsed
+            // by Hardhat's config loader, not by tsc or eslint.
+            'test/fixtures/**'
         ]
     },
     js.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "lint:fix": "prettier --write src/**/*.{js,ts} && prettier --write test/**/*.{js,ts} && eslint --fix src test",
         "lint": "eslint src test",
         "test": "mocha --exit --recursive 'test/**/*.test.ts'",
+        "smoke": "node scripts/smoke-test.mjs",
         "prepublishOnly": "tsc --project tsconfig.prod.json",
         "build": "tsc --project tsconfig.prod.json",
         "buidl": "tsc",

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Consumer smoke test.
+ *
+ * Unit tests load the plugin from source (`src/`). This script packs the
+ * package, installs it into a clean Hardhat 3 fixture, and asserts that the
+ * published layout can be loaded by Hardhat and that the `cli` task is
+ * registered. CI runs this so a broken published layout fails before release.
+ *
+ * Layout:
+ *   test/fixtures/smoke/   - minimal HH3 consumer project (committed)
+ *   scripts/smoke-test.mjs - this script (runs the install + assertions)
+ */
+
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, cpSync, readdirSync, existsSync } from 'node:fs'
+import { join, dirname, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(here, '..')
+const fixtureSrc = join(repoRoot, 'test', 'fixtures', 'smoke')
+
+function step(msg) {
+    process.stdout.write(`\n› ${msg}\n`)
+}
+
+function run(cmd, args, opts = {}) {
+    const display = `${cmd} ${args.join(' ')}`
+    process.stdout.write(`  $ ${display}\n`)
+    const result = spawnSync(cmd, args, { stdio: 'inherit', ...opts })
+    if (result.error) {
+        console.error(`✗ spawn error: ${result.error.message}`)
+        process.exit(1)
+    }
+    if (result.status !== 0) {
+        console.error(`✗ command failed (exit ${result.status}): ${display}`)
+        process.exit(result.status ?? 1)
+    }
+}
+
+const cleanup = []
+function trackForCleanup(dir) {
+    cleanup.push(dir)
+}
+
+function cleanupAll() {
+    for (const dir of cleanup) {
+        rmSync(dir, { recursive: true, force: true })
+    }
+}
+
+process.on('exit', cleanupAll)
+process.on('SIGINT', () => {
+    cleanupAll()
+    process.exit(130)
+})
+
+// 1. Build so dist/ matches what npm pack would ship.
+step('Building package (tsc)')
+run('npm', ['run', 'build'], { cwd: repoRoot })
+
+// 2. Pack the package into a temp directory.
+step('Packing package')
+const packDir = mkdtempSync(join(tmpdir(), 'hha-cli-pack-'))
+trackForCleanup(packDir)
+run('npm', ['pack', '--pack-destination', packDir], { cwd: repoRoot })
+
+const tarballs = readdirSync(packDir).filter((f) => f.endsWith('.tgz'))
+if (tarballs.length === 0) {
+    console.error('✗ npm pack produced no tarball')
+    process.exit(1)
+}
+const tarball = join(packDir, tarballs[0])
+process.stdout.write(`  tarball: ${tarball}\n`)
+
+// 3. Stage a copy of the fixture into a temp directory so we don't pollute
+//    the repo with a node_modules tree.
+step('Staging fixture')
+const stageDir = mkdtempSync(join(tmpdir(), 'hha-cli-smoke-'))
+trackForCleanup(stageDir)
+cpSync(fixtureSrc, stageDir, { recursive: true })
+
+// 4. Install the tarball + its peer (hardhat) into the fixture.
+step('Installing plugin into fixture')
+run(
+    'npm',
+    [
+        'install',
+        '--no-audit',
+        '--no-fund',
+        '--loglevel=error',
+        `hardhat-awesome-cli@${tarball}`
+    ],
+    { cwd: stageDir }
+)
+
+// 5a. Load hardhat inside the fixture and assert the `cli` task is registered.
+//     This catches problems where the published `exports` map, plugin entry,
+//     or hook handlers can't be resolved by Hardhat's plugin loader.
+step('Asserting plugin loads and `cli` task is registered')
+const loadCheck = `
+    import hardhat from 'hardhat'
+    const task = hardhat.tasks.getTask('cli')
+    if (!task) {
+        console.error('cli task not registered')
+        process.exit(1)
+    }
+    console.log('cli task id: ' + task.id.join(':'))
+    // Also confirm the resolved config picked up the plugin's paths.cli hook.
+    if (hardhat.config.paths.cli === undefined) {
+        console.error('paths.cli was not injected by the config hook')
+        process.exit(1)
+    }
+    console.log('paths.cli: ' + hardhat.config.paths.cli)
+`
+run(process.execPath, ['--input-type=module', '-e', loadCheck], { cwd: stageDir })
+
+// 5b. Invoke the installed `hardhat` binary's `--help` for the `cli` task so
+//     we know the CLI starts and prints help (catches runtime import errors
+//     in the lazy action module without running the interactive menu).
+//
+//     Hardhat 3 requires Node >= 22.13; on older Nodes (e.g. local dev with
+//     Node 20) the binary will refuse to start with a version error. The
+//     task-registration check above already covers the load path, so we
+//     skip this step on too-old Nodes rather than fail the whole smoke.
+const hhBin = join(stageDir, 'node_modules', '.bin', 'hardhat')
+if (!existsSync(hhBin)) {
+    console.error(`✗ hardhat binary not found at ${hhBin}`)
+    process.exit(1)
+}
+const nodeMajor = Number(process.versions.node.split('.')[0])
+const nodeMinor = Number(process.versions.node.split('.')[1])
+const nodeOk = nodeMajor > 22 || (nodeMajor === 22 && nodeMinor >= 13)
+if (!nodeOk) {
+    process.stdout.write(
+        `  ! Skipping \`hardhat cli --help\` (current Node ${process.versions.node} is below Hardhat 3's minimum of 22.13). The task-registration check above already exercises the load path.\n`
+    )
+} else {
+    step('Running `hardhat cli --help` in fixture')
+    run(hhBin, ['cli', '--help'], { cwd: stageDir })
+}
+
+// 6. Done.
+process.stdout.write('\n✓ Smoke test passed\n')

--- a/test/fixtures/smoke/.gitignore
+++ b/test/fixtures/smoke/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/test/fixtures/smoke/hardhat.config.ts
+++ b/test/fixtures/smoke/hardhat.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'hardhat/config'
+
+// The published layout: import the plugin via the subpath exposed in the
+// package's `exports` map (`./plugin` → `dist/src/plugin/index.js`).
+import hardhatAwesomeCli from 'hardhat-awesome-cli/plugin'
+
+export default defineConfig({
+    plugins: [hardhatAwesomeCli],
+    paths: {
+        cli: 'cli'
+    }
+})

--- a/test/fixtures/smoke/package.json
+++ b/test/fixtures/smoke/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "hha-cli-smoke-fixture",
+    "private": true,
+    "type": "module",
+    "version": "0.0.0",
+    "description": "Minimal Hardhat 3 consumer project used by the smoke test to verify the published layout of hardhat-awesome-cli loads and registers the `cli` task.",
+    "dependencies": {
+        "hardhat": "^3.0.0",
+        "hardhat-awesome-cli": "*"
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,10 @@
         "types": ["node", "mocha"],
         "esModuleInterop": true
     },
-    "exclude": ["dist", "node_modules"],
+    "exclude": [
+        "dist",
+        "node_modules",
+        "test/fixtures"
+    ],
     "include": ["./test", "./src"]
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -14,6 +14,10 @@
         "skipLibCheck": true,
         "rewriteRelativeImportExtensions": true
     },
-    "exclude": ["dist", "node_modules"],
+    "exclude": [
+        "dist",
+        "node_modules",
+        "test/fixtures"
+    ],
     "include": ["./test", "./src"]
 }


### PR DESCRIPTION
## Summary

Closes #175.

Unit tests load the plugin from source (`src/`) via a relative path, so a broken `package.json` `exports` map, plugin entry, or hook handler would slip through the mocha suite and only surface for downstream consumers after publish.

Add `npm run smoke` (and a CI `smoke` job depending on `build`) that:
1. Runs `tsc` so `dist/` matches the shipped layout.
2. Runs `npm pack` into a temp dir.
3. Copies `test/fixtures/smoke` — a minimal HH3 consumer project whose `hardhat.config.ts` imports the plugin from its published subpath (`hardhat-awesome-cli/plugin`) — into another temp dir.
4. Installs the tarball into the fixture.
5. Loads `hardhat` and asserts the `cli` task is registered and the config hook injected `paths.cli`.
6. Invokes `hardhat cli --help` to catch runtime errors in the lazy action module (skipped on Node < 22.13 since Hardhat 3 refuses to start there).

CI fails before release if the published layout can't be loaded by a fresh Hardhat project.

## Commits

- `build(lint,tsc): exclude test/fixtures from build and lint` — the fixture's `hardhat.config.ts` imports the package from its published subpath, which tsc/eslint can't resolve from inside the build. Skip both tools over `test/fixtures/**`.
- `ci: add consumer smoke test (npm pack + install into HH3 fixture)` — the smoke script, fixture, npm script, and CI job.

## Test plan

- [ ] `npm run smoke` passes locally (the task-registration assertion runs; the `--help` step is skipped because the local Node is below HH3's minimum — that's expected on Node 20).
- [ ] CI: `lint`, `build`, `test` jobs pass.
- [ ] CI: new `smoke` job (depends on `build`) passes on Node 24, where both the registration check and `hardhat cli --help` run.

## Out of scope

- README updates — happy to add a CI badge or "How we test" note if you want, but kept the diff minimal per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)