### PR TITLE
fix: make hardhat config mutation safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,10 @@ In 'More settings' you can also add a custom chain, create an issue or pull requ
 -   --remove-activated-chain Remove chains from the chain selection (default: "")
 -   --remove-hardhat-plugin Remove other Hardhat plugins (default: "")
 
+### Safe Hardhat plugin configuration updates
+
+For a typical Hardhat 3 `defineConfig({ plugins: [...] })` configuration, adding or removing a plugin updates both its ESM import and the `plugins` array. The generated plugin-array structure is checked before it replaces the original file. If the configuration shape is missing, ambiguous, or malformed, the CLI leaves the file untouched and prints the exact import and plugin entry to add manually. Legacy side-effect `require` and `import` configurations remain supported.
+
 ### Equivalent CLI command per menu selection
 
 When a menu selection maps to one of the CLI flags above (add/remove Hardhat plugins, add/remove activated chains, create GitHub workflows, install Foundry settings, install the Foundry test utility, …), the CLI prints the equivalent `npx hardhat cli --<flag> <value>` command line after the change is applied. This lets you skip the interactive prompts next time around, or wire the same action into a CI script.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "hardhat-awesome-cli",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "hardhat-awesome-cli",
-            "version": "0.1.4",
+            "version": "0.1.5",
             "license": "MIT",
             "dependencies": {
                 "dotenv": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hardhat-awesome-cli",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "Hardhat made awesome with a flexible CLI to help run test, deploy and more.",
     "repository": "https://github.com/marc-aurele-besner/hardhat-awesome-cli.git",
     "author": "Marc-Aurele Besner <82244926+marc-aurele-besner@users.noreply.github.com>",

--- a/src/packageInstaller.ts
+++ b/src/packageInstaller.ts
@@ -34,10 +34,98 @@ export const hardhatPluginImportName = (packageName: string): string => {
 export const isHardhat3Config = (hardhatConfigFile: string): boolean =>
     /\bdefineConfig\s*\(/.test(hardhatConfigFile) || /\bplugins\s*:\s*\[/.test(hardhatConfigFile)
 
-const importsPackage = (hardhatConfigFile: string, packageName: string): boolean =>
-    new RegExp(`from\\s*['"]${escapeForRegExp(packageName)}['"]`).test(hardhatConfigFile)
+const importsPackage = (hardhatConfigFile: string, packageName: string): boolean => {
+    const quoted = escapeForRegExp(packageName)
+    return new RegExp(String.raw`(?:from\s*|import\s*\(\s*|import\s*|require\s*\(\s*)['"]${quoted}['"]`).test(
+        hardhatConfigFile
+    )
+}
 
 const escapeForRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+export type HardhatConfigMutationFailureReason =
+    'no-plugins-array' | 'unterminated-plugins-array' | 'multiple-plugins-arrays'
+
+export interface HardhatConfigMutationFailure {
+    reason: HardhatConfigMutationFailureReason
+    message: string
+}
+
+interface PluginsArrayLocation {
+    start: number
+    end: number
+}
+
+const findPluginsArrays = (hardhatConfigFile: string): { locations: PluginsArrayLocation[]; unterminated: boolean } => {
+    const locations: PluginsArrayLocation[] = []
+    const pattern = /\bplugins\s*:\s*\[/g
+    let match: RegExpExecArray | null
+    let unterminated = false
+
+    while ((match = pattern.exec(hardhatConfigFile)) !== null) {
+        const start = match.index + match[0].length
+        let depth = 1
+        let quote: string | null = null
+        let escaped = false
+        let foundEnd = false
+
+        for (let index = start; index < hardhatConfigFile.length; index++) {
+            const char = hardhatConfigFile[index]
+            if (quote !== null) {
+                if (escaped) escaped = false
+                else if (char === '\\') escaped = true
+                else if (char === quote) quote = null
+                continue
+            }
+            if (char === '"' || char === "'" || char === '`') {
+                quote = char
+                continue
+            }
+            if (char === '[') depth++
+            else if (char === ']') {
+                depth--
+                if (depth === 0) {
+                    locations.push({ start, end: index })
+                    pattern.lastIndex = index + 1
+                    foundEnd = true
+                    break
+                }
+            }
+        }
+        if (!foundEnd) {
+            unterminated = true
+            break
+        }
+    }
+
+    return { locations, unterminated }
+}
+
+export const inspectHardhat3Config = (
+    hardhatConfigFile: string
+): PluginsArrayLocation | HardhatConfigMutationFailure => {
+    const { locations, unterminated } = findPluginsArrays(hardhatConfigFile)
+    if (unterminated)
+        return {
+            reason: 'unterminated-plugins-array',
+            message: 'The plugins array is not terminated.'
+        }
+    if (locations.length === 0)
+        return {
+            reason: 'no-plugins-array',
+            message: 'No plugins array was found.'
+        }
+    if (locations.length > 1)
+        return {
+            reason: 'multiple-plugins-arrays',
+            message: 'Multiple plugins arrays were found.'
+        }
+    return locations[0]
+}
+
+const isMutationFailure = (
+    result: PluginsArrayLocation | HardhatConfigMutationFailure
+): result is HardhatConfigMutationFailure => 'reason' in result
 
 /**
  * Split the content of an array literal on its top-level commas only, so an
@@ -76,20 +164,9 @@ const splitTopLevelEntries = (arrayContent: string): string[] => {
  * Locate the `plugins: [ ... ]` array of the config file and return the index
  * boundaries of its content, or `undefined` when there is no such array.
  */
-const findPluginsArray = (hardhatConfigFile: string): { start: number; end: number } | undefined => {
-    const match = hardhatConfigFile.match(/\bplugins\s*:\s*\[/)
-    if (match === null || match.index === undefined) return undefined
-    const start = match.index + match[0].length
-    let depth = 1
-    for (let index = start; index < hardhatConfigFile.length; index++) {
-        const char = hardhatConfigFile[index]
-        if (char === '[') depth++
-        else if (char === ']') {
-            depth--
-            if (depth === 0) return { start, end: index }
-        }
-    }
-    return undefined
+const findPluginsArray = (hardhatConfigFile: string): PluginsArrayLocation | undefined => {
+    const result = inspectHardhat3Config(hardhatConfigFile)
+    return isMutationFailure(result) ? undefined : result
 }
 
 /**
@@ -214,6 +291,67 @@ export const findHardhatConfigFilePath = (): string => {
     return ''
 }
 
+export interface HardhatConfigFileMutationResult {
+    updated: boolean
+    failure?: HardhatConfigMutationFailure
+}
+
+export const mutateHardhatConfigFile = (
+    hardhatConfigFilePath: string,
+    packageName: string,
+    addToConfig: boolean
+): HardhatConfigFileMutationResult => {
+    const hardhatConfigFile = fs.readFileSync(hardhatConfigFilePath, 'utf8')
+    const hardhat3 = isHardhat3Config(hardhatConfigFile)
+    if (hardhat3) {
+        const inspection = inspectHardhat3Config(hardhatConfigFile)
+        if (isMutationFailure(inspection)) return { updated: false, failure: inspection }
+    }
+
+    const newHardhatConfig = addToConfig
+        ? hardhat3
+            ? addPluginToHardhat3Config(hardhatConfigFile, packageName)
+            : addPluginToHardhat2Config(hardhatConfigFile, packageName)
+        : hardhat3
+          ? removePluginFromHardhat3Config(hardhatConfigFile, packageName)
+          : removePluginFromHardhat2Config(hardhatConfigFile, packageName)
+    if (newHardhatConfig === undefined)
+        return {
+            updated: false,
+            failure: {
+                reason: 'no-plugins-array',
+                message: 'No supported plugin registration location was found.'
+            }
+        }
+    if (newHardhatConfig === hardhatConfigFile) return { updated: false }
+
+    const extension = path.extname(hardhatConfigFilePath)
+    const temporaryPath = `${hardhatConfigFilePath}.hardhat-awesome-cli${extension || '.js'}`
+    try {
+        fs.writeFileSync(temporaryPath, newHardhatConfig)
+        if (isHardhat3Config(newHardhatConfig) && isMutationFailure(inspectHardhat3Config(newHardhatConfig)))
+            throw new Error('The generated plugins array is invalid.')
+        fs.renameSync(temporaryPath, hardhatConfigFilePath)
+        return { updated: true }
+    } catch (error) {
+        fs.rmSync(temporaryPath, { force: true })
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+            updated: false,
+            failure: {
+                reason: 'unterminated-plugins-array',
+                message: `The generated config did not pass syntax validation: ${message}`
+            }
+        }
+    }
+}
+
+const manualConfigSnippet = (packageName: string, hardhat3: boolean): string =>
+    hardhat3
+        ? `import ${hardhatPluginImportName(packageName)} from '${packageName}'\n` +
+          `... defineConfig({ plugins: [${hardhatPluginImportName(packageName)}] })`
+        : `require('${packageName}')`
+
 const importPackageHardhatConfigFile = async (packageName: string, addToConfig: boolean, removeFromConfig: boolean) => {
     const hardhatConfigFilePath = findHardhatConfigFilePath()
     if (!hardhatConfigFilePath) {
@@ -231,25 +369,17 @@ const importPackageHardhatConfigFile = async (packageName: string, addToConfig: 
             )
             return
         }
-        const newHardhatConfig = hardhat3
-            ? addPluginToHardhat3Config(hardhatConfigFile, packageName)
-            : addPluginToHardhat2Config(hardhatConfigFile, packageName)
-        if (newHardhatConfig === undefined) {
+        const mutation = mutateHardhatConfigFile(hardhatConfigFilePath, packageName, true)
+        if (mutation.failure !== undefined) {
             console.log(
                 '\x1b[31m%s\x1b[0m',
-                'Could not update ' + hardhatConfigFilePath + ' automatically, please add it yourself:'
+                'Could not update ' + hardhatConfigFilePath + ' automatically: ' + mutation.failure.message
             )
-            if (hardhat3)
-                console.log(
-                    '\x1b[97m%s\x1b[0m',
-                    `import ${hardhatPluginImportName(packageName)} from '${packageName}'\n` +
-                        `... defineConfig({ plugins: [${hardhatPluginImportName(packageName)}] })`
-                )
-            else console.log('\x1b[97m%s\x1b[0m', `require('${packageName}')`)
+            console.log('\x1b[97m%s\x1b[0m', manualConfigSnippet(packageName, hardhat3))
             return
         }
-        console.log('\x1b[33m%s\x1b[0m', 'Adding ' + packageName + ' to your ' + hardhatConfigFilePath + ' file')
-        fs.writeFileSync(hardhatConfigFilePath, newHardhatConfig)
+        if (mutation.updated)
+            console.log('\x1b[33m%s\x1b[0m', 'Added ' + packageName + ' to your ' + hardhatConfigFilePath + ' file')
         return
     }
 
@@ -258,11 +388,17 @@ const importPackageHardhatConfigFile = async (packageName: string, addToConfig: 
             console.log('\x1b[34m%s\x1b[0m', 'Package ' + packageName + ' not found in ' + hardhatConfigFilePath)
             return
         }
-        console.log('\x1b[33m%s\x1b[0m', 'Removing ' + packageName + ' from your ' + hardhatConfigFilePath + ' file')
-        const newHardhatConfig = hardhat3
-            ? removePluginFromHardhat3Config(hardhatConfigFile, packageName)
-            : removePluginFromHardhat2Config(hardhatConfigFile, packageName)
-        fs.writeFileSync(hardhatConfigFilePath, newHardhatConfig)
+        const mutation = mutateHardhatConfigFile(hardhatConfigFilePath, packageName, false)
+        if (mutation.failure !== undefined) {
+            console.log(
+                '\x1b[31m%s\x1b[0m',
+                'Could not update ' + hardhatConfigFilePath + ' automatically: ' + mutation.failure.message
+            )
+            console.log('\x1b[97m%s\x1b[0m', manualConfigSnippet(packageName, hardhat3))
+            return
+        }
+        if (mutation.updated)
+            console.log('\x1b[33m%s\x1b[0m', 'Removed ' + packageName + ' from your ' + hardhatConfigFilePath + ' file')
     }
 }
 

--- a/test/fixtures/packageInstaller/hardhat.config.ts
+++ b/test/fixtures/packageInstaller/hardhat.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'hardhat/config'
+import hardhatAwesomeCli from 'hardhat-awesome-cli/plugin'
+
+export default defineConfig({
+    plugins: [hardhatAwesomeCli],
+    solidity: '0.8.28'
+})

--- a/test/packageInstaller.test.ts
+++ b/test/packageInstaller.test.ts
@@ -9,7 +9,9 @@ import {
     addPluginToHardhat3Config,
     findHardhatConfigFilePath,
     hardhatPluginImportName,
+    inspectHardhat3Config,
     isHardhat3Config,
+    mutateHardhatConfigFile,
     removePluginFromHardhat3Config
 } from '../src/packageInstaller.ts'
 import type { IHardhatPluginAvailableList } from '../src/types.ts'
@@ -133,6 +135,82 @@ describe('packageInstaller', function () {
 
             expect(removed).to.include('plugins: []')
             expect(removed).to.not.include('@nomicfoundation/hardhat-viem')
+        })
+    })
+
+    describe('inspectHardhat3Config', function () {
+        it('rejects configs without a plugins array explicitly', function () {
+            const result = inspectHardhat3Config(`export default defineConfig({ solidity: '0.8.28' })`)
+
+            expect(result).to.deep.include({ reason: 'no-plugins-array' })
+        })
+
+        it('rejects configs with multiple plugins arrays explicitly', function () {
+            const result = inspectHardhat3Config(
+                `export default defineConfig({ plugins: [], nested: { plugins: [] } })`
+            )
+
+            expect(result).to.deep.include({ reason: 'multiple-plugins-arrays' })
+        })
+
+        it('rejects an unterminated plugins array explicitly', function () {
+            const result = inspectHardhat3Config(`export default defineConfig({ plugins: [hardhatAwesomeCli })`)
+
+            expect(result).to.deep.include({ reason: 'unterminated-plugins-array' })
+        })
+    })
+
+    describe('mutateHardhatConfigFile', function () {
+        const initialCwd = process.cwd()
+        let fixtureDirectory: string
+        let configPath: string
+
+        beforeEach(function () {
+            fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-mutation-'))
+            process.chdir(fixtureDirectory)
+            configPath = path.join(fixtureDirectory, 'hardhat.config.ts')
+        })
+
+        afterEach(function () {
+            process.chdir(initialCwd)
+            fs.rmSync(fixtureDirectory, { recursive: true, force: true })
+        })
+
+        it('adds and removes a plugin in a fixture config without breaking syntax', function () {
+            const fixturePath = path.join(initialCwd, 'test/fixtures/packageInstaller/hardhat.config.ts')
+            const source = fs.readFileSync(fixturePath, 'utf8')
+            fs.writeFileSync(configPath, source)
+
+            expect(mutateHardhatConfigFile(configPath, '@nomicfoundation/hardhat-ethers', true)).to.deep.equal({
+                updated: true
+            })
+            const added = fs.readFileSync(configPath, 'utf8')
+            expect(added).to.include(`import hardhatEthers from '@nomicfoundation/hardhat-ethers'`)
+            expect(added).to.include('plugins: [hardhatAwesomeCli, hardhatEthers]')
+            const checkPath = path.join(fixtureDirectory, 'hardhat.config.mjs')
+            fs.writeFileSync(checkPath, added)
+            expect(() => execFileSync(process.execPath, ['--check', checkPath])).to.not.throw()
+
+            expect(mutateHardhatConfigFile(configPath, '@nomicfoundation/hardhat-ethers', false)).to.deep.equal({
+                updated: true
+            })
+            expect(fs.readFileSync(configPath, 'utf8')).to.equal(source)
+        })
+
+        it('leaves an unsupported config untouched and reports the reason', function () {
+            const source = `import { defineConfig } from 'hardhat/config'\nexport default defineConfig({ solidity: '0.8.28' })\n`
+            fs.writeFileSync(configPath, source)
+
+            const result = mutateHardhatConfigFile(configPath, '@nomicfoundation/hardhat-ethers', true)
+
+            expect(result.failure).to.deep.include({ reason: 'no-plugins-array' })
+            expect(fs.readFileSync(configPath, 'utf8')).to.equal(source)
+            expect(fs.existsSync(`${configPath}.hardhat-awesome-cli.ts`)).to.equal(false)
+        })
+
+        it('recognizes side-effect imports and require calls', function () {
+            expect(isHardhat3Config(`import '@nomicfoundation/hardhat-ethers'\nplugins: []`)).to.equal(true)
+            expect(isHardhat3Config(`require('@nomicfoundation/hardhat-ethers')\nplugins: []`)).to.equal(true)
         })
     })
 


### PR DESCRIPTION
## Summary

- detect missing, malformed, and ambiguous Hardhat 3 plugin arrays before editing
- stage config changes and atomically replace the original only after structural validation
- print actionable manual snippets when automatic updates are unsafe
- add fixture-based add/remove coverage and document the behavior
- bump the package version to 0.1.5

## Other Information

Closes #158

Verification:
- `npm run lint`
- `npm run build`
- `npm test` (139 passing)
- `npm run smoke`