### PR TITLE
feat(installer): pnpm + bun support for install, remove, and CI workflows (#171)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,10 @@ export default defineConfig({
     -   Install/Uninstall other Hardhat plugins
 
         The plugin list targets Hardhat 3: the CLI installs the package with
-        npm/yarn, adds `import <plugin> from '<package>'` to your
-        `hardhat.config`, and registers it in the `plugins` array of
-        `defineConfig(...)` (Hardhat 3 dropped side-effect plugin registration).
+        npm/yarn/pnpm/bun (auto-detected from your lockfile), adds
+        `import <plugin> from '<package>'` to your `hardhat.config`, and
+        registers it in the `plugins` array of `defineConfig(...)` (Hardhat
+        3 dropped side-effect plugin registration).
 
           <details>
               <summary>Plugins offered</summary>
@@ -160,7 +161,7 @@ export default defineConfig({
 
           </details>
 
-    -   Create Github test workflows (for NPM and/or Yarn and for Hardhat test&coverage and/or Foundry test)
+    -   Create Github test workflows (for NPM, Yarn, pnpm, or Bun and for Hardhat test&coverage and/or Foundry test)
     -   Create Foundry settings, remapping and test utilities
           <details>
               <summary>More details on Foundry</summary>
@@ -215,6 +216,28 @@ export default defineConfig({
 -   Avalanche - Fuji (chainId: 43113)
 
 In 'More settings' you can also add a custom chain, create an issue or pull request to add other chains.
+
+### Package manager support
+
+The CLI picks the package manager it uses (for installing/removing plugins,
+adding the `foundry-test-utility`, and printing the equivalent `npx hardhat
+cli` command) by inspecting the lockfile at the project root, in this
+priority order:
+
+1. `pnpm-lock.yaml` → **pnpm** (`pnpm add -D <pkg>` / `pnpm remove <pkg>`)
+2. `bun.lock` / `bun.lockb` → **bun** (`bun add -d <pkg>` / `bun remove <pkg>`)
+3. `yarn.lock` → **yarn** (`yarn add <pkg> -D` / `yarn remove <pkg>`)
+4. `package-lock.json` → **npm** (`npm install <pkg> --save-dev` / `npm remove <pkg>`)
+5. no recognised lockfile → **npm** (default)
+
+pnpm and bun win over npm/yarn on purpose so a project that happens to
+also carry a `package-lock.json` (created when a contributor clones with
+npm) still resolves to the right manager. The same lookup drives the CI
+workflow generator: the `Create Github test workflows` menu and the
+`--addGithubTestWorkflow` flag now offer a Hardhat + Foundry workflow
+per supported package manager (`hardhat-pnpm.yml`, `foundry-pnpm.yml`,
+`hardhat-bun.yml`, `foundry-bun.yml`) in addition to the existing npm
+and yarn templates.
 
 ## CLI optional flags
 
@@ -592,13 +615,18 @@ hardhat-awesome-cli/
 │   ├── functionList.ts
 │   ├── index.ts
 │   ├── packageInstaller.ts
+│   ├── packageManager.ts
 │   ├── serveInquirer.ts
 │   ├── types.ts
 │   ├── utils.ts
 │   ├── githubWorkflows/
+│   │   ├── foundry-bun.yml
 │   │   ├── foundry-npm.yml
+│   │   ├── foundry-pnpm.yml
 │   │   ├── foundry-yarn.yml
+│   │   ├── hardhat-bun.yml
 │   │   ├── hardhat-npm.yml
+│   │   ├── hardhat-pnpm.yml
 │   │   └── hardhat-yarn.yml
 │   ├── mockContracts/
 │   │   ├── index.ts

--- a/src/config.ts
+++ b/src/config.ts
@@ -327,7 +327,7 @@ export const DefaultFoundryTestUtilsList: string[] = [
     'utils/Vm.sol'
 ]
 
-export const DefaultGithubWorkflowsGroup: string[] = ['npm', 'yarn']
+export const DefaultGithubWorkflowsGroup: string[] = ['npm', 'yarn', 'pnpm', 'bun']
 
 export const DefaultGithubWorkflowsList: IDefaultGithubWorkflowsList[] = [
     {
@@ -351,6 +351,28 @@ export const DefaultGithubWorkflowsList: IDefaultGithubWorkflowsList[] = [
         title: 'Yarn - Foundry - Forge Test',
         file: 'foundry-yarn',
         group: 'yarn'
+    },
+    {
+        title: 'pnpm - Hardhat - Test & Coverage',
+        file: 'hardhat-pnpm',
+        group: 'pnpm',
+        requirement: ['solidity-coverage']
+    },
+    {
+        title: 'pnpm - Foundry - Forge Test',
+        file: 'foundry-pnpm',
+        group: 'pnpm'
+    },
+    {
+        title: 'Bun - Hardhat - Test & Coverage',
+        file: 'hardhat-bun',
+        group: 'bun',
+        requirement: ['solidity-coverage']
+    },
+    {
+        title: 'Bun - Foundry - Forge Test',
+        file: 'foundry-bun',
+        group: 'bun'
     }
 ]
 

--- a/src/githubWorkflows/foundry-bun.yml
+++ b/src/githubWorkflows/foundry-bun.yml
@@ -1,0 +1,23 @@
+name: Run Foundry Test with Bun
+
+on: [push]
+
+jobs:
+  test_foundry_bun:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+      - name: Install Foundry
+        uses: onbjerg/foundry-toolchain@v1
+        with:
+          version: nightly
+      - name: Bun Install
+        run: bun install --frozen-lockfile
+      - name: Run Forge Test
+        run: forge test

--- a/src/githubWorkflows/foundry-pnpm.yml
+++ b/src/githubWorkflows/foundry-pnpm.yml
@@ -1,0 +1,24 @@
+name: Run Foundry Test with pnpm
+
+on: [push]
+
+jobs:
+  test_foundry_pnpm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install Foundry
+        uses: onbjerg/foundry-toolchain@v1
+        with:
+          version: nightly
+      - name: pnpm Install
+        run: pnpm install --frozen-lockfile
+      - name: Run Forge Test
+        run: forge test

--- a/src/githubWorkflows/hardhat-bun.yml
+++ b/src/githubWorkflows/hardhat-bun.yml
@@ -1,0 +1,25 @@
+name: Run Hardhat Test with Bun
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  test_hardhat_bun:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+      - name: Bun Frozen Install
+        run: bun install --frozen-lockfile
+      - name: Hardhat Compile
+        run: bunx hardhat compile
+      - name: Hardhat Test
+        run: bunx hardhat test
+      - name: Hardhat Coverage Result
+        run: bunx hardhat coverage

--- a/src/githubWorkflows/hardhat-pnpm.yml
+++ b/src/githubWorkflows/hardhat-pnpm.yml
@@ -1,0 +1,26 @@
+name: Run Hardhat Test with pnpm
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  test_hardhat_pnpm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: pnpm Frozen Install
+        run: pnpm install --frozen-lockfile
+      - name: Hardhat Compile
+        run: pnpm hardhat compile
+      - name: Hardhat Test
+        run: pnpm hardhat test
+      - name: Hardhat Coverage Result
+        run: pnpm hardhat coverage

--- a/src/packageInstaller.ts
+++ b/src/packageInstaller.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 
+import { getPackageManagerCommands, lockfileDetectionLabel } from './packageManager.ts'
 import { runCommand } from './utils.ts'
 
 /**
@@ -417,29 +418,21 @@ const detectPackage = async (
     if (fs.existsSync(path.join(nodeModulesPath, packageName))) {
         if (uninstall) {
             console.log('\x1b[34m%s\x1b[0m', 'Uninstalling package: ', '\x1b[97m\x1b[0m', packageName)
-            if (fs.existsSync('package-lock.json')) {
-                if (addRemoveInHardhatConfig) await importPackageHardhatConfigFile(packageName, false, true)
-                // Wait for `npm remove` to actually finish; previously this
-                // relied on a 5s sleep which was both slow and unreliable.
-                await runCommand('npm remove ' + packageName, '', '', false)
-            } else if (fs.existsSync('yarn-lock.json')) {
-                if (addRemoveInHardhatConfig) await importPackageHardhatConfigFile(packageName, false, true)
-                await runCommand('yarn remove ' + packageName, '', '', false)
-            }
+            const { manager, commands } = getPackageManagerCommands()
+            console.log('\x1b[33m%s\x1b[0m', lockfileDetectionLabel(manager))
+            if (addRemoveInHardhatConfig) await importPackageHardhatConfigFile(packageName, false, true)
+            // Wait for the package manager to actually finish; previously this
+            // relied on a 5s sleep which was both slow and unreliable.
+            await runCommand(commands.remove(packageName), '', '', false)
         }
         return true
     } else {
         if (install) {
             console.log('\x1b[34m%s\x1b[0m', 'Installing package: ', '\x1b[97m\x1b[0m', packageName)
-            if (fs.existsSync('package-lock.json')) {
-                console.log('\x1b[33m%s\x1b[0m', 'Detected package-lock.json, installing with npm')
-                if (addRemoveInHardhatConfig) await importPackageHardhatConfigFile(packageName, true, false)
-                await runCommand('npm install ' + packageName, '', ' --save-dev', false)
-            } else if (fs.existsSync('yarn-lock.json')) {
-                console.log('\x1b[33m%s\x1b[0m', 'Detected yarn-lock.json, installing with yarn')
-                if (addRemoveInHardhatConfig) await importPackageHardhatConfigFile(packageName, true, false)
-                await runCommand('yarn add ' + packageName, '', ' -D', false)
-            }
+            const { manager, commands } = getPackageManagerCommands()
+            console.log('\x1b[33m%s\x1b[0m', lockfileDetectionLabel(manager))
+            if (addRemoveInHardhatConfig) await importPackageHardhatConfigFile(packageName, true, false)
+            await runCommand(commands.installDev(packageName), '', '', false)
         }
         return false
     }

--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -1,0 +1,140 @@
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Package manager supported by the installer and CI workflow generator.
+ *
+ * The CLI picks one per invocation by looking at the lockfile at the project
+ * root, in this priority order:
+ *
+ *   pnpm-lock.yaml → pnpm
+ *   bun.lock / bun.lockb → bun
+ *   yarn.lock → yarn
+ *   package-lock.json → npm
+ *   (no recognised lockfile) → npm (default)
+ *
+ * The order matters: a project can ship both `package-lock.json` (for example,
+ * created when contributors clone with npm) and `yarn.lock` (the file the team
+ * actually uses). pnpm / bun win because their lockfile is a stronger signal
+ * than the npm / yarn pair; npm wins over yarn because it is the historic
+ * fallback and is the default when nothing matches.
+ */
+export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun'
+
+/**
+ * Lockfile marker for each supported package manager. The runtime check is
+ * `fs.existsSync` against `path.join(cwd, file)` — the working directory the
+ * CLI was invoked from. The CLI is already cwd-based elsewhere (see
+ * `packageInstaller.ts`), so we do not have to walk parents to find the
+ * project root.
+ */
+const PACKAGE_MANAGER_LOCKFILES: Record<PackageManager, string[]> = {
+    npm: ['package-lock.json'],
+    yarn: ['yarn.lock'],
+    pnpm: ['pnpm-lock.yaml'],
+    bun: ['bun.lock', 'bun.lockb']
+}
+
+/**
+ * Priority used by `detectPackageManager`: a package manager earlier in the
+ * list always wins when more than one lockfile is present. pnpm / bun are
+ * intentionally first so a project that happens to also carry
+ * `package-lock.json` resolves to the right manager.
+ */
+const DETECTION_ORDER: PackageManager[] = ['pnpm', 'bun', 'yarn', 'npm']
+
+/**
+ * Look at the lockfiles in the given directory and return the matching
+ * package manager. Defaults to the current working directory so callers
+ * never have to pass `process.cwd()` explicitly.
+ *
+ * Detection is cwd-only on purpose: a CLI that walks parents to find a
+ * package.json would surprise the user running it from a sub-directory (a
+ * sub-package of a monorepo, a CI scratch dir, etc). If the cwd carries no
+ * recognised lockfile the detection falls back to npm, mirroring the
+ * historic behaviour of the installer before multi-manager support was
+ * added.
+ */
+export const detectPackageManager = (cwd: string = process.cwd()): PackageManager => {
+    for (const candidate of DETECTION_ORDER) {
+        const lockfiles = PACKAGE_MANAGER_LOCKFILES[candidate]
+        if (lockfiles.some((file) => fs.existsSync(path.join(cwd, file)))) return candidate
+    }
+    return 'npm'
+}
+
+export interface PackageManagerCommands {
+    /** Fully-qualified install command for a single package as a dev dep, e.g. `npm install foo --save-dev`. */
+    installDev: (packageName: string) => string
+    /** Fully-qualified install command for a single package as a regular dep, e.g. `npm install foo`. */
+    install: (packageName: string) => string
+    /** Fully-qualified remove command for a single package, e.g. `npm remove foo`. */
+    remove: (packageName: string) => string
+    /** Plain install command that uses the lockfile (no package argument), e.g. `npm ci`. */
+    installFrozen: string
+}
+
+/**
+ * Command templates per package manager. Centralised here so both the
+ * installer (`packageInstaller.ts`) and the GitHub workflow templates stay
+ * in sync — if a flag ever changes (e.g. bun moving away from `-d`) there
+ * is exactly one place to update.
+ */
+export const PACKAGE_MANAGER_COMMANDS: Record<PackageManager, PackageManagerCommands> = {
+    npm: {
+        installDev: (packageName) => `npm install ${packageName} --save-dev`,
+        install: (packageName) => `npm install ${packageName}`,
+        remove: (packageName) => `npm remove ${packageName}`,
+        installFrozen: 'npm ci'
+    },
+    yarn: {
+        installDev: (packageName) => `yarn add ${packageName} -D`,
+        install: (packageName) => `yarn add ${packageName}`,
+        remove: (packageName) => `yarn remove ${packageName}`,
+        installFrozen: 'yarn install --frozen-lockfile'
+    },
+    pnpm: {
+        installDev: (packageName) => `pnpm add -D ${packageName}`,
+        install: (packageName) => `pnpm add ${packageName}`,
+        remove: (packageName) => `pnpm remove ${packageName}`,
+        installFrozen: 'pnpm install --frozen-lockfile'
+    },
+    bun: {
+        installDev: (packageName) => `bun add -d ${packageName}`,
+        install: (packageName) => `bun add ${packageName}`,
+        remove: (packageName) => `bun remove ${packageName}`,
+        installFrozen: 'bun install --frozen-lockfile'
+    }
+}
+
+/**
+ * Resolve the package manager used by the current project and return the
+ * matching command templates. Returned object is intentionally narrow (no
+ * raw lockfile data) so callers cannot accidentally depend on the cwd state
+ * the detection ran against.
+ */
+export const getPackageManagerCommands = (
+    cwd?: string
+): { manager: PackageManager; commands: PackageManagerCommands } => {
+    const manager = detectPackageManager(cwd)
+    return { manager, commands: PACKAGE_MANAGER_COMMANDS[manager] }
+}
+
+/**
+ * Label printed by the installer when it makes a package-manager driven
+ * decision, e.g. `Detected pnpm-lock.yaml, installing with pnpm`. Kept here
+ * rather than in `packageInstaller.ts` so the test suite can assert against
+ * one canonical string.
+ */
+export const lockfileDetectionLabel = (manager: PackageManager): string => {
+    switch (manager) {
+        case 'npm':
+            return 'Detected package-lock.json, installing with npm'
+        case 'yarn':
+            return 'Detected yarn.lock, installing with yarn'
+        case 'pnpm':
+            return 'Detected pnpm-lock.yaml, installing with pnpm'
+        case 'bun':
+            return 'Detected bun.lock, installing with bun'
+    }
+}

--- a/test/githubWorkflows.test.ts
+++ b/test/githubWorkflows.test.ts
@@ -34,20 +34,48 @@ describe('DefaultGithubWorkflowsList group metadata', function () {
         })
     })
 
-    it('Has one npm and one yarn entry per tooling (Hardhat / Foundry)', function () {
+    it('Tags pnpm workflows with group "pnpm"', function () {
+        const pnpmWorkflows = DefaultGithubWorkflowsList.filter(
+            (workflow: IDefaultGithubWorkflowsList) => workflow.group === 'pnpm'
+        )
+        expect(pnpmWorkflows.length).to.equal(2)
+        expect(pnpmWorkflows.map((workflow) => workflow.file)).to.have.members(['hardhat-pnpm', 'foundry-pnpm'])
+    })
+
+    it('Tags bun workflows with group "bun"', function () {
+        const bunWorkflows = DefaultGithubWorkflowsList.filter(
+            (workflow: IDefaultGithubWorkflowsList) => workflow.group === 'bun'
+        )
+        expect(bunWorkflows.length).to.equal(2)
+        expect(bunWorkflows.map((workflow) => workflow.file)).to.have.members(['hardhat-bun', 'foundry-bun'])
+    })
+
+    it('Has one entry per (group, tooling) combination', function () {
         // Guards against the original bug where every entry was tagged npm,
         // which made serveWorkflowBuilder list both yarn items under "npm".
+        // After pnpm + bun were added, each tooling also ships a variant.
         const groupCounts = DefaultGithubWorkflowsList.reduce<Record<string, number>>((counts, workflow) => {
             counts[workflow.group] = (counts[workflow.group] ?? 0) + 1
             return counts
         }, {})
         expect(groupCounts.npm).to.equal(2)
         expect(groupCounts.yarn).to.equal(2)
+        expect(groupCounts.pnpm).to.equal(2)
+        expect(groupCounts.bun).to.equal(2)
     })
 })
 
 describe('Generated GitHub workflow YAMLs', function () {
-    const yamlFiles = ['hardhat-npm.yml', 'hardhat-yarn.yml', 'foundry-npm.yml', 'foundry-yarn.yml']
+    const yamlFiles = [
+        'hardhat-npm.yml',
+        'hardhat-yarn.yml',
+        'hardhat-pnpm.yml',
+        'hardhat-bun.yml',
+        'foundry-npm.yml',
+        'foundry-yarn.yml',
+        'foundry-pnpm.yml',
+        'foundry-bun.yml'
+    ]
 
     yamlFiles.forEach((fileName: string) => {
         describe(fileName, function () {
@@ -70,6 +98,12 @@ describe('Generated GitHub workflow YAMLs', function () {
             it('Mentions the install command that matches its group', function () {
                 if (fileName.includes('yarn')) {
                     expect(content).to.include('yarn')
+                    expect(content).to.not.match(/npm ci\b/)
+                } else if (fileName.includes('pnpm')) {
+                    expect(content).to.include('pnpm')
+                    expect(content).to.not.match(/npm ci\b/)
+                } else if (fileName.includes('bun')) {
+                    expect(content).to.include('bun')
                     expect(content).to.not.match(/npm ci\b/)
                 } else {
                     expect(content).to.match(/npm (ci|install)/)

--- a/test/packageManager.test.ts
+++ b/test/packageManager.test.ts
@@ -1,0 +1,146 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import {
+    PACKAGE_MANAGER_COMMANDS,
+    detectPackageManager,
+    getPackageManagerCommands,
+    lockfileDetectionLabel
+} from '../src/packageManager.ts'
+
+describe('packageManager', function () {
+    describe('detectPackageManager', function () {
+        const initialCwd = process.cwd()
+        let fixtureDirectory: string
+
+        beforeEach(function () {
+            fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-pm-'))
+            process.chdir(fixtureDirectory)
+        })
+
+        afterEach(function () {
+            process.chdir(initialCwd)
+            fs.rmSync(fixtureDirectory, { recursive: true, force: true })
+        })
+
+        it('returns npm when only package-lock.json is present', function () {
+            fs.writeFileSync(path.join(fixtureDirectory, 'package-lock.json'), '{}')
+
+            expect(detectPackageManager()).to.equal('npm')
+        })
+
+        it('returns yarn when only yarn.lock is present', function () {
+            fs.writeFileSync(path.join(fixtureDirectory, 'yarn.lock'), '')
+
+            expect(detectPackageManager()).to.equal('yarn')
+        })
+
+        it('returns pnpm when only pnpm-lock.yaml is present', function () {
+            fs.writeFileSync(path.join(fixtureDirectory, 'pnpm-lock.yaml'), '')
+
+            expect(detectPackageManager()).to.equal('pnpm')
+        })
+
+        it('returns bun when bun.lock is present', function () {
+            fs.writeFileSync(path.join(fixtureDirectory, 'bun.lock'), '')
+
+            expect(detectPackageManager()).to.equal('bun')
+        })
+
+        it('returns bun when the binary bun.lockb is present', function () {
+            fs.writeFileSync(path.join(fixtureDirectory, 'bun.lockb'), Buffer.from([]))
+
+            expect(detectPackageManager()).to.equal('bun')
+        })
+
+        it('prefers pnpm over yarn / npm when both lockfiles are present', function () {
+            fs.writeFileSync(path.join(fixtureDirectory, 'pnpm-lock.yaml'), '')
+            fs.writeFileSync(path.join(fixtureDirectory, 'yarn.lock'), '')
+            fs.writeFileSync(path.join(fixtureDirectory, 'package-lock.json'), '{}')
+
+            expect(detectPackageManager()).to.equal('pnpm')
+        })
+
+        it('prefers bun over yarn / npm when both lockfiles are present', function () {
+            fs.writeFileSync(path.join(fixtureDirectory, 'bun.lock'), '')
+            fs.writeFileSync(path.join(fixtureDirectory, 'yarn.lock'), '')
+            fs.writeFileSync(path.join(fixtureDirectory, 'package-lock.json'), '{}')
+
+            expect(detectPackageManager()).to.equal('bun')
+        })
+
+        it('falls back to npm when no recognised lockfile is present', function () {
+            expect(detectPackageManager()).to.equal('npm')
+        })
+
+        it('accepts an explicit directory and ignores the live cwd', function () {
+            fs.writeFileSync(path.join(fixtureDirectory, 'yarn.lock'), '')
+            const otherDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-pm-other-'))
+            try {
+                fs.writeFileSync(path.join(otherDirectory, 'pnpm-lock.yaml'), '')
+                expect(detectPackageManager(otherDirectory)).to.equal('pnpm')
+                expect(detectPackageManager(fixtureDirectory)).to.equal('yarn')
+            } finally {
+                fs.rmSync(otherDirectory, { recursive: true, force: true })
+            }
+        })
+    })
+
+    describe('PACKAGE_MANAGER_COMMANDS', function () {
+        it('uses --save-dev for npm and -D for yarn / pnpm / bun', function () {
+            expect(PACKAGE_MANAGER_COMMANDS.npm.installDev('foo')).to.equal('npm install foo --save-dev')
+            expect(PACKAGE_MANAGER_COMMANDS.yarn.installDev('foo')).to.equal('yarn add foo -D')
+            expect(PACKAGE_MANAGER_COMMANDS.pnpm.installDev('foo')).to.equal('pnpm add -D foo')
+            expect(PACKAGE_MANAGER_COMMANDS.bun.installDev('foo')).to.equal('bun add -d foo')
+        })
+
+        it('uses an fpm-compatible frozen install for every manager', function () {
+            for (const commands of Object.values(PACKAGE_MANAGER_COMMANDS)) {
+                expect(commands.installFrozen, 'frozen install must be defined').to.be.a('string')
+                expect(commands.installFrozen.length).to.be.greaterThan(0)
+            }
+        })
+
+        it('quotes the remove command without any save flag', function () {
+            expect(PACKAGE_MANAGER_COMMANDS.npm.remove('foo')).to.equal('npm remove foo')
+            expect(PACKAGE_MANAGER_COMMANDS.yarn.remove('foo')).to.equal('yarn remove foo')
+            expect(PACKAGE_MANAGER_COMMANDS.pnpm.remove('foo')).to.equal('pnpm remove foo')
+            expect(PACKAGE_MANAGER_COMMANDS.bun.remove('foo')).to.equal('bun remove foo')
+        })
+    })
+
+    describe('getPackageManagerCommands', function () {
+        const initialCwd = process.cwd()
+        let fixtureDirectory: string
+
+        beforeEach(function () {
+            fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-pm-'))
+            process.chdir(fixtureDirectory)
+        })
+
+        afterEach(function () {
+            process.chdir(initialCwd)
+            fs.rmSync(fixtureDirectory, { recursive: true, force: true })
+        })
+
+        it('returns a matching command bundle for a pnpm project', function () {
+            fs.writeFileSync(path.join(fixtureDirectory, 'pnpm-lock.yaml'), '')
+
+            const result = getPackageManagerCommands()
+
+            expect(result.manager).to.equal('pnpm')
+            expect(result.commands.installDev('foo')).to.equal('pnpm add -D foo')
+        })
+    })
+
+    describe('lockfileDetectionLabel', function () {
+        it('uses the lockfile name that triggered the detection', function () {
+            expect(lockfileDetectionLabel('npm')).to.equal('Detected package-lock.json, installing with npm')
+            expect(lockfileDetectionLabel('yarn')).to.equal('Detected yarn.lock, installing with yarn')
+            expect(lockfileDetectionLabel('pnpm')).to.equal('Detected pnpm-lock.yaml, installing with pnpm')
+            expect(lockfileDetectionLabel('bun')).to.equal('Detected bun.lock, installing with bun')
+        })
+    })
+})


### PR DESCRIPTION
## Summary

Closes #171.

The installer used to look only for `package-lock.json` / `yarn.lock`,
so a pnpm or bun project silently fell through to npm and mutated the
wrong lockfile. This change threads pnpm and bun through the same code
paths that npm and yarn already use, and gives the GitHub workflow
generator a matching template per (manager, tooling).

## What changed

- New `src/packageManager.ts` owns the lockfile lookup and the
  per-manager command templates so the installer and the workflow
  generator share one source of truth. pnpm and bun win over npm/yarn
  when both are present because their lockfile is a stronger signal
  that the team actually uses them; no recognised lockfile still falls
  back to npm so freshly-cloned projects keep working.
- `src/packageInstaller.ts` routes `install` / `remove` through the new
  helper instead of duplicating the npm / yarn branches.
- Four new GitHub Actions templates (`hardhat-pnpm.yml`,
  `foundry-pnpm.yml`, `hardhat-bun.yml`, `foundry-bun.yml`) wired into
  `DefaultGithubWorkflowsList` and `DefaultGithubWorkflowsGroup`, so
  `Create Github test workflows` and `--addGithubTestWorkflow` offer
  them alongside npm / yarn.

## Tests

- New `test/packageManager.test.ts` covers lockfile priority
  (pnpm > yarn > npm, bun > yarn > npm), the bun.lock / bun.lockb pair,
  the default fallback, the explicit `cwd` override, the per-manager
  command templates, and the detection label printed to stdout.
- `test/githubWorkflows.test.ts` extended so the pnpm + bun groups and
  yaml files are asserted next to the existing npm + yarn ones (the
  install-command match check now branches on the file name).

`npm run lint`, `npm run build`, and `npm test` (172 passing) all
green from a clean tree.

## Docs

- README gains a "Package manager support" subsection with the
  lockfile priority order and the install commands each one maps to.
- The plugin blurb, the GitHub workflow description, and the project
  directory tree are updated to mention pnpm + bun and to list the new
  files.

## Acceptance criteria

- [x] Plugin install works in a pnpm project
- [x] At least one pnpm workflow template is available (Hardhat + Foundry)