### PR TITLE
feat(rename): rename and customize mock contracts via CLI (#167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,29 @@ export default defineConfig({
     > CommonJS variant from the same template at write time — no duplicate files
     > to keep in sync.
 
+    Issue #167 — after picking a mock contract, the CLI now asks for a
+    custom contract name (default: the registry name) plus optional
+    constructor name and symbol. The contract file, the deployment script,
+    the Hardhat test, and the Foundry test are all rewritten in place so
+    every reference — identifier, import path, `getContractFactory` call,
+    `describe(...)` title, `_TEST_NAME` literal — points at the custom
+    name end-to-end. A validation step rejects invalid Solidity
+    identifiers (e.g. `1Token`, `My-Token`) and names that would shadow
+    the inherited contract (`ERC20`, `ERC721Upgradeable`,
+    `Initializable`, …).
+
+    The CLI prints the equivalent command for scripting — the same rename
+    is reachable without prompts via:
+
+    ```bash
+    npx hardhat cli --addCustomMockContract "MockERC20:MyToken:MyToken:MOCK"
+    ```
+
+    The colon-separated value is
+    `<registryName>:<customName>:<constructorName>:<constructorSymbol>`.
+    Hitting Enter at every interactive prompt keeps the registry defaults
+    so existing users stay on the stock `MockERC20` flow.
+
 -   Get account balance
 
 ### Current chain support

--- a/src/buildMockContracts.ts
+++ b/src/buildMockContracts.ts
@@ -29,7 +29,203 @@ const resolveMockContractsPath = (): string | undefined => {
     return candidates.find((candidate) => fs.existsSync(path.join(candidate, 'MockERC20.sol')))
 }
 
-const buildMockContract = async (contractName: string) => {
+/**
+ * Optional inputs accepted by `buildMockContract` and
+ * `buildMockDeploymentScriptOrTest` so a user can rename and customize a mock
+ * contract through the CLI (issue #167).
+ *
+ * - `customName` overrides the contract identifier across every generated
+ *   artifact (Solidity source, deploy script, Hardhat test, Foundry test).
+ * - `constructorArgs` replaces the default name/symbol string literals passed
+ *   to the inherited constructor (or initializer for upgradeable mocks).
+ *
+ * When both fields are omitted the function behaves exactly as before — the
+ *   `MockERC20` / `MockERC721` / … flow stays untouched.
+ */
+export interface IRenameOptions {
+    customName?: string
+    constructorArgs?: string[]
+}
+
+const camelCase = (name: string): string => {
+    if (name.length === 0) return name
+    return name[0].toLowerCase() + name.slice(1)
+}
+
+const kebabCase = (name: string): string =>
+    name
+        // Insert a hyphen between a lowercase/digit and an uppercase letter
+        // (e.g. `MyToken` → `my-token`, `MyERC20` → `my-erc20`).
+        .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+        .toLowerCase()
+
+const escapeForDoubleQuotes = (value: string): string => value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+
+/**
+ * Rewrite a mock-contract template so every identifier, import path,
+ * constructor literal and test reference points at the renamed contract.
+ *
+ * The substitution strategy is deterministic and intentionally simple:
+ *
+ * 1. Walk the source line-by-line so multi-line replacements do not collide.
+ * 2. Replace the registry-supplied name (`MockERC20`) with the user-supplied
+ *    name everywhere it appears — including `import { MockERC20 } from …`,
+ *    `describe('MockERC20', ...)`, and `getContractFactory('MockERC20')`.
+ * 3. Replace the camelCase variant (`mockERC20`) with the camelCase form of
+ *    the user-supplied name.
+ * 4. For upgradeable mocks, also rewrite the `__<Name>_init` /
+ *    `__<Name>_init_unchained` internal helpers the template emits so the
+ *    rename is self-consistent.
+ * 5. Override the constructor string literals when `constructorArgs` is set,
+ *    in the order the parent contract consumes them (name first, symbol
+ *    second for ERC20/721/1155 families).
+ *
+ * Returning the rendered text keeps the function pure and easy to test in
+ * isolation — the callers (`buildMockContract` /
+ * `buildMockDeploymentScriptOrTest`) are responsible for the file IO and the
+ * path routing.
+ */
+export const renderMockTemplate = (
+    raw: string,
+    contract: IMockContractsList,
+    options: IRenameOptions = {}
+): string => {
+    if (!options.customName && (!options.constructorArgs || options.constructorArgs.length === 0)) {
+        return raw
+    }
+
+    const sourceName = contract.name
+    const customName = options.customName ?? sourceName
+    const sourceCamel = camelCase(sourceName)
+    const customCamel = camelCase(customName)
+
+    const lines = raw.split('\n')
+    const out: string[] = []
+
+    // Track the next constructor-argument slot to substitute. Each iteration
+    // first counts how many literals on the original line fall inside the
+    // parent constructor signature, then performs that many substitutions in
+    // source order. We never touch literals after the parent constructor on
+    // the same line because the mock templates do not emit any.
+    let constructorArgIndex = 0
+
+    for (const originalLine of lines) {
+        let line = originalLine
+
+        // Constructor / initializer literals MUST be rewritten before the
+        // identifier rename — the literal `'MockERC20'` shares the same
+        // substring as the registry name, so the identifier pass would
+        // collapse both into the custom name and the literal substitution
+        // would no longer match.
+        if (options.constructorArgs && options.constructorArgs.length > 0) {
+            const matchCount = countConstructorLiterals(originalLine)
+            const take = Math.min(matchCount, options.constructorArgs.length - constructorArgIndex)
+            if (take > 0) {
+                line = substituteConstructorLiterals(line, options.constructorArgs, take, constructorArgIndex)
+                constructorArgIndex += take
+            }
+        }
+
+        // Rename `__<SourceName>_init` / `__<SourceName>_init_unchained`
+        // helper calls (upgradeable mocks only). We only touch the
+        // double-underscore prefix so we do not collide with the constructor
+        // string literal below.
+        if (contract.upgradeable) {
+            const initPattern = new RegExp(`__${sourceName}_init`, 'g')
+            line = line.replace(initPattern, `__${customName}_init`)
+        }
+
+        // Replace the registry name and its camelCase variant with the
+        // user-supplied form. Order matters: do the original name first so a
+        // rename to a name that overlaps the original (e.g. `MockERC20` →
+        // `mockERC20`) does not rewrite the camelCase form incorrectly.
+        line = line.split(sourceName).join(customName)
+        if (sourceCamel !== customCamel) {
+            line = line.split(sourceCamel).join(customCamel)
+        }
+
+        out.push(line)
+    }
+
+    return out.join('\n')
+}
+
+/**
+ * Match the parent constructor call on a single Solidity / TS line. We only
+ * recognise the OpenZeppelin-style signatures the bundled mocks emit:
+ *
+ * - Non-upgradeable: `ERC20('Name', 'Symbol')`, `ERC721(...)`,
+ *   `ERC1155(...)`
+ * - Upgradeable: `__<Name>_init('Name', 'Symbol')` /
+ *   `__<Name>_init_unchained('Name', 'Symbol')`
+ *
+ * Anchoring on the parent identifier keeps the substitution off the test
+ * title (`describe('MockERC20', ...)`) and other unrelated string literals
+ * that may live further down the same line.
+ */
+const PARENT_CONSTRUCTOR_PATTERN = /\b(ERC20|ERC721|ERC1155|ERC20Upgradeable|ERC721Upgradeable|ERC1155Upgradeable|ProxyAdmin|TransparentUpgradeableProxy|__\w+_init)\s*\(/
+
+/**
+ * Count the number of string literals that fall inside the parent
+ * constructor signature on `line`. Used to advance the constructor-argument
+ * index after each substitution pass without affecting unrelated literals
+ * (e.g. the test title `describe('MockERC20', ...)`).
+ */
+const countConstructorLiterals = (line: string): number => {
+    const callMatch = line.match(PARENT_CONSTRUCTOR_PATTERN)
+    if (!callMatch || callMatch.index === undefined) return 0
+    const openParen = callMatch.index + callMatch[0].length - 1
+    const closeParen = line.indexOf(')', openParen)
+    if (closeParen === -1) return 0
+    const inside = line.slice(openParen + 1, closeParen)
+    const literalMatches = inside.match(/(['"])([^'"\n]*?)\1/g)
+    return literalMatches ? literalMatches.length : 0
+}
+
+/**
+ * Rewrite the string literals inside the parent constructor signature on
+ * `line` with the next `take` entries of `args` (in source order).
+ *
+ * We anchor on the parent-constructor identifier (e.g. `ERC20(`, `__Foo_init(`)
+ * so the substitution only touches literals that belong to the constructor —
+ * the test title `describe('MockERC20', ...)` lives further down the line
+ * and is handled by the identifier rename pass that follows.
+ */
+const substituteConstructorLiterals = (
+    line: string,
+    args: string[],
+    take: number,
+    startIndex: number
+): string => {
+    const callMatch = line.match(PARENT_CONSTRUCTOR_PATTERN)
+    if (!callMatch || callMatch.index === undefined) return line
+    const openParen = callMatch.index + callMatch[0].length - 1
+    const closeParen = line.indexOf(')', openParen)
+    if (closeParen === -1) return line
+
+    const literalPattern = /(['"])([^'"\n]*?)\1/g
+    let index = startIndex
+    let count = 0
+    const before = line.slice(0, openParen + 1)
+    const middle = line.slice(openParen + 1, closeParen)
+    const after = line.slice(closeParen)
+
+    const rewritten = middle.replace(literalPattern, (_match, quote, value) => {
+        if (count >= take || index >= args.length) {
+            count++
+            return `${quote}${value}${quote}`
+        }
+        const replacement = escapeForDoubleQuotes(args[index])
+        index++
+        count++
+        return `${quote}${replacement}${quote}`
+    })
+
+    return before + rewritten + after
+}
+
+const buildMockContract = async (contractName: string, options: IRenameOptions = {}) => {
     const packageRootPath = resolveMockContractsPath()
     if (!packageRootPath) return
 
@@ -45,14 +241,17 @@ const buildMockContract = async (contractName: string) => {
     )
     if (contractToMock.length === 0) return
 
-    const contractFile = `contracts/${contractName}.sol`
+    const finalName = options.customName ?? contractName
+    const contractFile = `contracts/${finalName}.sol`
     if (fs.existsSync(contractFile)) {
         console.log('\x1b[33m%s\x1b[0m', 'Mock contract already exists')
         return
     }
 
-    console.log('\x1b[32m%s\x1b[0m', 'Creating ', contractName, ' in contracts/')
-    fs.copyFileSync(path.join(packageRootPath, `${contractName}.sol`), contractFile)
+    console.log('\x1b[32m%s\x1b[0m', 'Creating ', finalName, ' in contracts/')
+    const rawTemplate = fs.readFileSync(path.join(packageRootPath, `${contractName}.sol`), 'utf8')
+    const rendered = renderMockTemplate(rawTemplate, contractToMock[0], options)
+    fs.writeFileSync(contractFile, rendered)
 
     if (contractToMock[0].dependencies && contractToMock[0].dependencies.length > 0) {
         for (const dependency of contractToMock[0].dependencies) {
@@ -84,41 +283,87 @@ const swapExtension = (filePath: string, target: 'ts' | 'js' | 'sol'): string =>
     return filePath.replace(/\.ts$/, '.js')
 }
 
-export const buildMockDeploymentScriptOrTest = async (contractName: string, type: string) => {
+/**
+ * Resolve the path the consumer receives for a given mock artifact type
+ * (deployment, test, Foundry test). When `customName` is provided the path
+ * uses the kebab-case form of the custom name so the filename matches the
+ * pattern users expect from the bundled mocks (`deploy-Mock-ERC20.ts`,
+ * `test-Mock-ERC20.ts`).
+ */
+const resolveArtifactPath = (
+    contract: IMockContractsList,
+    type: 'deployment' | 'test' | 'testForge',
+    customName: string | undefined,
+    extension: 'ts' | 'js' | 'sol'
+): { finalPath: string; scriptOrTestDir: string; templatePath: string } | undefined => {
+    let templatePath: string
+    let scriptOrTestDir: string
+    let customPathTemplate: string
+
+    if (type === 'deployment') {
+        if (!contract.deploymentScript) return undefined
+        templatePath = contract.deploymentScript
+        scriptOrTestDir = 'scripts'
+        if (customName) {
+            customPathTemplate = `scripts/deploy-${kebabCase(customName)}.${extension}`
+        } else {
+            customPathTemplate = templatePath
+        }
+    } else if (type === 'test') {
+        if (!contract.testScript) return undefined
+        templatePath = contract.testScript
+        scriptOrTestDir = 'test'
+        if (customName) {
+            customPathTemplate = `test/test-${kebabCase(customName)}.${extension}`
+        } else {
+            customPathTemplate = templatePath
+        }
+    } else if (type === 'testForge') {
+        if (!contract.testContractFoundry) return undefined
+        templatePath = contract.testContractFoundry
+        scriptOrTestDir = 'contracts/test'
+        if (customName) {
+            customPathTemplate = `contracts/test/${customName}.t.sol`
+        } else {
+            customPathTemplate = templatePath.replace('testForge/', 'contracts/test/')
+        }
+    } else {
+        return undefined
+    }
+
+    const finalPath = swapExtension(customPathTemplate || templatePath, extension)
+    // Foundry templates live under `src/mockContracts/testForge/` in the
+    // package, while the consumer-side file lives under `contracts/test/`.
+    // Return the package-relative template path so the caller can read the
+    // source bytes for rendering.
+    return { finalPath, scriptOrTestDir, templatePath }
+}
+
+export const buildMockDeploymentScriptOrTest = async (
+    contractName: string,
+    type: 'deployment' | 'test' | 'testForge',
+    options: IRenameOptions = {}
+) => {
     const packageRootPath = resolveMockContractsPath()
     if (!packageRootPath) return
     if (!MockContractsList) return
 
-    let templatePath: string = ''
-    let finalPath: string = ''
-    let scriptOrTestDir: string = ''
     const contractToMock: IMockContractsList[] = MockContractsList.filter(
         (contract) => contract.name === contractName
     )
     if (contractToMock.length === 0) return
 
-    if (type === 'deployment') {
-        scriptOrTestDir = 'scripts'
-        if (contractToMock[0].deploymentScript === undefined) return
-        templatePath = contractToMock[0].deploymentScript
-    } else if (type === 'test') {
-        scriptOrTestDir = 'test'
-        if (contractToMock[0].testScript === undefined) return
-        templatePath = contractToMock[0].testScript
-    } else if (type === 'testForge') {
-        scriptOrTestDir = 'contracts/test'
-        if (contractToMock[0]?.testContractFoundry === undefined) return
-        templatePath = contractToMock[0].testContractFoundry
-        finalPath = templatePath.replace('testForge/', 'contracts/test/')
-    }
+    const contractEntry = contractToMock[0]
+    const customName = options.customName
 
-    if (!templatePath) return
-
+    // Pick the destination extension: Foundry tests stay Solidity, everything
+    // else follows the consumer's Hardhat config.
     const targetExtension = pickArtifactExtension()
-    // Foundry test contracts are Solidity (`.sol`) — never affected by the
-    // TS/JS choice. Everything else follows the user's Hardhat config.
     const writeExtension: 'ts' | 'js' | 'sol' = type === 'testForge' ? 'sol' : targetExtension
-    finalPath = swapExtension(finalPath || templatePath, writeExtension)
+
+    const resolved = resolveArtifactPath(contractEntry, type, customName, writeExtension)
+    if (!resolved) return
+    const { finalPath, scriptOrTestDir, templatePath } = resolved
 
     // Ensure the destination directory exists before writing. `recursive: true`
     // is a no-op when the directory is already there, so this is safe to run
@@ -131,10 +376,11 @@ export const buildMockDeploymentScriptOrTest = async (contractName: string, type
         return
     }
 
-    console.log('\x1b[32m%s\x1b[0m', 'Creating ' + type + ' for ', contractName, ' in ' + scriptOrTestDir + '/')
+    console.log('\x1b[32m%s\x1b[0m', 'Creating ' + type + ' for ', customName ?? contractName, ' in ' + scriptOrTestDir + '/')
     const rawData: string = fs.readFileSync(path.join(packageRootPath, templatePath), 'utf8')
-    const rendered = writeExtension === 'js' ? transformTsToJs(rawData) : rawData
-    fs.writeFileSync(finalPath, rendered)
+    const rendered = renderMockTemplate(rawData, contractEntry, options)
+    const output = writeExtension === 'js' ? transformTsToJs(rendered) : rendered
+    fs.writeFileSync(finalPath, output)
 }
 
 export default buildMockContract

--- a/src/renameMockContract.ts
+++ b/src/renameMockContract.ts
@@ -1,0 +1,244 @@
+import type { IMockContractsList } from './types.ts'
+
+/**
+ * Validators for renaming a mock contract (issue #167).
+ *
+ * `isValidSolidityIdentifier` enforces the Solidity identifier grammar plus
+ * the reserved-word list so the renamed artifact compiles without surprises.
+ * `inheritanceConflicts` flags names that would shadow the parent contract
+ * (or any other identifier the template relies on), which Solidity rejects
+ * because `contract Foo is ERC20` and `contract ERC20 is …` cannot coexist in
+ * the same source unit.
+ *
+ * Both helpers stay pure so the inquirer prompt flow and the
+ * `--addCustomMockContract` CLI flag can share the same validation.
+ */
+
+// Solidity reserved words that the language spec forbids as identifiers.
+// Sourced from https://docs.soliditylang.org/en/latest/grammar.html (the
+// "Reserved Keywords" and "Keywords" lists). We do not try to be exhaustive
+// across every legacy version — we only need the words a mock-contract name
+// could plausibly collide with.
+const SOLIDITY_RESERVED_WORDS = new Set<string>([
+    'abstract',
+    'after',
+    'alias',
+    'apply',
+    'auto',
+    'bool',
+    'break',
+    'byte',
+    'case',
+    'catch',
+    'char',
+    'class',
+    'const',
+    'constant',
+    'continue',
+    'contract',
+    'default',
+    'define',
+    'delete',
+    'do',
+    'else',
+    'emit',
+    'enum',
+    'error',
+    'event',
+    'external',
+    'false',
+    'final',
+    'fixed',
+    'for',
+    'function',
+    'hex',
+    'if',
+    'immutable',
+    'implements',
+    'import',
+    'in',
+    'indexed',
+    'interface',
+    'internal',
+    'is',
+    'library',
+    'mapping',
+    'match',
+    'memory',
+    'modifier',
+    'new',
+    'null',
+    'of',
+    'override',
+    'partial',
+    'payable',
+    'pragma',
+    'private',
+    'protected',
+    'public',
+    'pure',
+    'receive',
+    'return',
+    'returns',
+    'revert',
+    'sealed',
+    'sizeof',
+    'static',
+    'storage',
+    'string',
+    'struct',
+    'switch',
+    'this',
+    'throw',
+    'true',
+    'try',
+    'type',
+    'typedef',
+    'typeid',
+    'typeof',
+    'uint',
+    'unchecked',
+    'unicode',
+    'using',
+    'var',
+    'view',
+    'virtual',
+    'void',
+    'volatile',
+    'while',
+    'address',
+    'int',
+    'int8',
+    'int16',
+    'int32',
+    'int64',
+    'int128',
+    'int256',
+    'uint8',
+    'uint16',
+    'uint32',
+    'uint64',
+    'uint128',
+    'uint256',
+    'bytes',
+    'bytes1',
+    'bytes2',
+    'bytes4',
+    'bytes8',
+    'bytes16',
+    'bytes20',
+    'bytes24',
+    'bytes28',
+    'bytes32'
+])
+
+// TypeScript / JavaScript reserved words the deploy script and Hardhat test
+// templates emit (e.g. `let`, `const`, `function`). A rename that produces a
+// TS keyword would silently break the generated source files, so reject it.
+const TS_RESERVED_WORDS = new Set<string>([
+    'break',
+    'case',
+    'catch',
+    'class',
+    'const',
+    'continue',
+    'debugger',
+    'default',
+    'delete',
+    'do',
+    'else',
+    'enum',
+    'export',
+    'extends',
+    'false',
+    'finally',
+    'for',
+    'function',
+    'if',
+    'import',
+    'in',
+    'instanceof',
+    'new',
+    'null',
+    'return',
+    'super',
+    'switch',
+    'this',
+    'throw',
+    'true',
+    'try',
+    'typeof',
+    'var',
+    'void',
+    'while',
+    'with',
+    'yield',
+    'let',
+    'async',
+    'await',
+    'of'
+])
+
+const IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+/**
+ * `true` when the supplied string is a legal Solidity (and TypeScript)
+ * identifier and does not collide with a reserved word from either language.
+ */
+export const isValidSolidityIdentifier = (name: string): boolean => {
+    if (typeof name !== 'string') return false
+    if (name.length === 0) return false
+    if (!IDENTIFIER_PATTERN.test(name)) return false
+    if (SOLIDITY_RESERVED_WORDS.has(name)) return false
+    if (TS_RESERVED_WORDS.has(name)) return false
+    return true
+}
+
+/**
+ * Inherited identifier map for the bundled mock contracts.
+ *
+ * The templates declare their parent contracts via the `is` clause and the
+ * OpenZeppelin `import` statement. We encode the parent names here so the
+ * conflict check works without parsing the `.sol` file at runtime.
+ *
+ * Keys are the registry `IMockContractsList.name` field; values are the
+ * identifier strings the source file references (and therefore cannot be
+ * shadowed by the renamed contract).
+ */
+const INHERITED_IDENTIFIERS: Record<string, string[]> = {
+    MockERC20: ['ERC20'],
+    MockERC721: ['ERC721'],
+    MockERC1155: ['ERC1155'],
+    MockERC20Upgradeable: ['ERC20Upgradeable', 'Initializable'],
+    MockERC721Upgradeable: ['ERC721Upgradeable', 'Initializable'],
+    MockERC1155Upgradeable: ['ERC1155Upgradeable', 'Initializable'],
+    MockProxyAdmin: ['ProxyAdmin'],
+    MockTransparentUpgradeableProxy: ['TransparentUpgradeableProxy']
+}
+
+/**
+ * Return the list of inherited identifiers (e.g. `ERC20`, `Initializable`)
+ * that a rename would shadow. Empty array means the new name is safe.
+ */
+export const inheritanceConflicts = (customName: string, contract: IMockContractsList): string[] => {
+    if (typeof customName !== 'string') return []
+    const inherited = INHERITED_IDENTIFIERS[contract.name] ?? []
+    return inherited.filter((parent) => parent === customName)
+}
+
+/**
+ * One-shot validator used by the inquirer `validate` callback and the
+ * `--addCustomMockContract` CLI flag. Returns `true` when the supplied name
+ * is acceptable, otherwise a human-readable error string inquirer can
+ * surface inline.
+ */
+export const validateRename = (customName: string, contract: IMockContractsList): true | string => {
+    if (!isValidSolidityIdentifier(customName)) {
+        return 'Contract name must start with a letter or underscore and contain only letters, digits and underscores, and must not be a Solidity or TypeScript reserved word.'
+    }
+    const conflicts = inheritanceConflicts(customName, contract)
+    if (conflicts.length > 0) {
+        return `Contract name conflicts with inherited identifier(s): ${conflicts.join(', ')}.`
+    }
+    return true
+}

--- a/src/serveInquirer.ts
+++ b/src/serveInquirer.ts
@@ -31,6 +31,7 @@ import {
 } from './config.ts'
 import MockContractsList from './mockContracts/index.ts'
 import detectPackage from './packageInstaller.ts'
+import { validateRename } from './renameMockContract.ts'
 import {
     IChain,
     IDefaultGithubWorkflowsList,
@@ -108,6 +109,11 @@ interface MockContractDetailsAnswer {
     mockDeploymentScript: string
     mockTestScript: string
     mockTestContractFoundry: string
+}
+interface MockContractRenameAnswer {
+    customName: string
+    constructorName: string
+    constructorSymbol: string
 }
 interface MainMenuAnswer {
     action: string
@@ -746,14 +752,148 @@ const serveMockContractCreatorSelector = async () => {
         }
     })()
     if (!mockContractsToAdd) return
-    for (const mockContract of mockContractsToAdd.mockContracts) {
-        await buildMockContract(mockContract)
+    for (const mockContractEntry of mockContractsSelectedDetail) {
+        // Issue #167: ask for a custom name and constructor arguments before
+        // writing the artifacts. Hitting Enter keeps the registry defaults so
+        // the menu stays backward-compatible with users who just want a stock
+        // `MockERC20` mock.
+        const renameAnswers = await collectRenameAnswers(mockContractEntry)
+        if (!renameAnswers) continue
+        await buildMockContract(mockContractEntry.name, renameAnswers)
         if (mockContractsToAdd.mockDeploymentScript === 'yes')
-            await buildMockDeploymentScriptOrTest(mockContract, 'deployment')
-        if (mockContractsToAdd.mockTestScript === 'yes') await buildMockDeploymentScriptOrTest(mockContract, 'test')
+            await buildMockDeploymentScriptOrTest(mockContractEntry.name, 'deployment', renameAnswers)
+        if (mockContractsToAdd.mockTestScript === 'yes')
+            await buildMockDeploymentScriptOrTest(mockContractEntry.name, 'test', renameAnswers)
         if (mockContractsToAdd.mockTestContractFoundry === 'yes')
-            await buildMockDeploymentScriptOrTest(mockContract, 'testForge')
+            await buildMockDeploymentScriptOrTest(mockContractEntry.name, 'testForge', renameAnswers)
+        displayFinalCliCommand(
+            'addCustomMockContract',
+            formatAddCustomMockContractFlag(
+                mockContractEntry.name,
+                renameAnswers.customName,
+                renameAnswers.constructorName,
+                renameAnswers.constructorSymbol
+            )
+        )
     }
+}
+
+/**
+ * Prompt the user for a custom contract name and constructor arguments, then
+ * validate the result. Returns `undefined` when the user did not supply
+ * anything (we bail out instead of forcing a name) so callers can skip the
+ * entry on Ctrl-C.
+ *
+ * Hitting Enter at every prompt keeps the registry defaults
+ * (`<registryName>`, `<registryName>`, `MOCK`).
+ */
+const collectRenameAnswers = async (
+    contract: IMockContractsList
+): Promise<{ customName: string; constructorName: string; constructorSymbol: string } | undefined> => {
+    const renameQuestions = [
+        {
+            type: 'input',
+            name: 'customName',
+            message: `Contract name (default: ${contract.name})`,
+            default: contract.name,
+            validate: (input: string) => validateRename(input, contract)
+        },
+        {
+            type: 'input',
+            name: 'constructorName',
+            message: `Constructor name (default: ${contract.name})`,
+            default: contract.name,
+            validate: (input: string) => (input.trim().length > 0 ? true : 'Constructor name cannot be empty')
+        },
+        {
+            type: 'input',
+            name: 'constructorSymbol',
+            message: `Constructor symbol (default: MOCK)`,
+            default: 'MOCK',
+            validate: (input: string) => (input.trim().length > 0 ? true : 'Constructor symbol cannot be empty')
+        }
+    ]
+    try {
+        const answer = await inquirer.prompt<MockContractRenameAnswer>(renameQuestions)
+        return answer
+    } catch {
+        // The user aborted the prompt (Ctrl-C) — leave the entry untouched
+        // rather than writing a partial artifact set.
+        return undefined
+    }
+}
+
+/**
+ * Render the value consumed by `--addCustomMockContract` so the printed
+ * CLI command round-trips through `parseAddCustomMockContractFlag`.
+ *
+ * Shape: `<registryName>:<customName>:<constructorName>:<constructorSymbol>`.
+ * `:` is used as the delimiter because contract names, constructor strings
+ * and symbols cannot contain it without becoming hard to escape.
+ */
+export const formatAddCustomMockContractFlag = (
+    registryName: string,
+    customName: string,
+    constructorName: string,
+    constructorSymbol: string
+): string => `${registryName}:${customName}:${constructorName}:${constructorSymbol}`
+
+/**
+ * Parse the `--addCustomMockContract` CLI flag value.
+ *
+ * Returns `undefined` when the value is malformed (wrong number of
+ * segments) so `serveCli` can fall through to the next flag instead of
+ * silently invoking the rename with garbage.
+ */
+export const parseAddCustomMockContractFlag = (
+    value: string | undefined
+): { registryName: string; customName: string; constructorName: string; constructorSymbol: string } | undefined => {
+    if (typeof value !== 'string') return undefined
+    const parts = value.split(':')
+    if (parts.length !== 4) return undefined
+    const [registryName, customName, constructorName, constructorSymbol] = parts
+    if (!registryName || !customName || !constructorName || !constructorSymbol) return undefined
+    return { registryName, customName, constructorName, constructorSymbol }
+}
+
+/**
+ * Generate a customized mock contract from a CLI flag (issue #167).
+ *
+ * Reuses the same rename renderer as the interactive flow but skips the
+ * inquirer prompts so the flag stays scriptable. The flag value is parsed
+ * via `parseAddCustomMockContractFlag`; a malformed value aborts the
+ * operation with a yellow warning rather than throwing.
+ */
+const runAddCustomMockContract = async (
+    registryName: string,
+    customName: string,
+    constructorName: string,
+    constructorSymbol: string
+): Promise<void> => {
+    const entry = MockContractsList?.find((contract) => contract.name === registryName)
+    if (!entry) {
+        console.log(
+            '\x1b[33m%s\x1b[0m',
+            `Unknown mock contract "${registryName}". Available: ${(MockContractsList ?? [])
+                .map((contract) => contract.name)
+                .join(', ')}`
+        )
+        return
+    }
+    const validation = validateRename(customName, entry)
+    if (validation !== true) {
+        console.log('\x1b[33m%s\x1b[0m', validation)
+        return
+    }
+    const options = {
+        customName,
+        constructorArgs: [constructorName, constructorSymbol]
+    }
+    await buildMockContract(registryName, options)
+    if (entry.deploymentScript) await buildMockDeploymentScriptOrTest(registryName, 'deployment', options)
+    if (entry.testScript) await buildMockDeploymentScriptOrTest(registryName, 'test', options)
+    if (entry.testContractFoundry && fs.existsSync('contracts/test') && fs.existsSync('foundry.toml'))
+        await buildMockDeploymentScriptOrTest(registryName, 'testForge', options)
 }
 
 const serveDeploymentContractCreatorSelector = async () => {}
@@ -807,6 +947,7 @@ interface ICliArgs {
     addActivatedChain?: string
     removeActivatedChain?: string
     getAccountBalance?: string
+    addCustomMockContract?: string
 }
 
 const serveInquirer = async (env: IHreContext) => {
@@ -928,6 +1069,22 @@ const serveCli = async (args: ICliArgs, env: IHreContext) => {
             return removeActivatedChain(args.removeActivatedChain)
         case isAffirmativeString(args.getAccountBalance):
             return serveAccountBalance(env)
+        case isPresentString(args.addCustomMockContract): {
+            const parsed = parseAddCustomMockContractFlag(args.addCustomMockContract)
+            if (!parsed) {
+                console.log(
+                    '\x1b[33m%s\x1b[0m',
+                    'Invalid --addCustomMockContract value. Expected "<registryName>:<customName>:<constructorName>:<constructorSymbol>".'
+                )
+                return
+            }
+            return runAddCustomMockContract(
+                parsed.registryName,
+                parsed.customName,
+                parsed.constructorName,
+                parsed.constructorSymbol
+            )
+        }
         default:
             return serveInquirer(env)
     }

--- a/test/buildMockContracts.test.ts
+++ b/test/buildMockContracts.test.ts
@@ -236,4 +236,76 @@ describe('buildMockContracts (issue #168)', function () {
             }
         })
     })
+
+    // Issue #167 — every generated artifact (Solidity, deploy script, Hardhat
+    // test, Foundry test) must use the user-supplied contract name and
+    // constructor arguments end-to-end. The renderer rewrites the templates
+    // at write time, so the registry templates under `src/mockContracts/`
+    // stay the single source of truth.
+    describe('rename path (issue #167)', function () {
+        const renameOptions = { customName: 'MyToken', constructorArgs: ['USD Coin', 'USDC'] }
+
+        it('writes the Solidity source with the custom name and constructor args', async function () {
+            await buildMockContract('MockERC20', renameOptions)
+
+            expect(fs.existsSync('contracts/MyToken.sol')).to.equal(true)
+            const source = fs.readFileSync('contracts/MyToken.sol', 'utf8')
+            expect(source).to.contain('contract MyToken is ERC20')
+            expect(source).to.contain("ERC20('USD Coin', 'USDC')")
+            // The original `MockERC20` identifier should no longer appear.
+            expect(source).to.not.contain('MockERC20')
+        })
+
+        it('writes the deploy script with the custom name', async function () {
+            await buildMockContract('MockERC20', renameOptions)
+            await buildMockDeploymentScriptOrTest('MockERC20', 'deployment', renameOptions)
+
+            expect(fs.existsSync('scripts/deploy-my-token.ts')).to.equal(true)
+            const script = fs.readFileSync('scripts/deploy-my-token.ts', 'utf8')
+            expect(script).to.contain("getContractFactory('MyToken')")
+            expect(script).to.contain("saveContract('MyToken'")
+            expect(script).to.not.contain('MockERC20')
+        })
+
+        it('writes the Hardhat test with the custom name', async function () {
+            await buildMockContract('MockERC20', renameOptions)
+            await buildMockDeploymentScriptOrTest('MockERC20', 'test', renameOptions)
+
+            expect(fs.existsSync('test/test-my-token.ts')).to.equal(true)
+            const test = fs.readFileSync('test/test-my-token.ts', 'utf8')
+            expect(test).to.contain("describe('MyToken'")
+            expect(test).to.contain("getContractFactory('MyToken')")
+            expect(test).to.not.contain('MockERC20')
+        })
+
+        it('writes the Foundry test with the custom name', async function () {
+            await buildMockContract('MockERC20', renameOptions)
+            await buildMockDeploymentScriptOrTest('MockERC20', 'testForge', renameOptions)
+
+            expect(fs.existsSync('contracts/test/MyToken.t.sol')).to.equal(true)
+            const forgeTest = fs.readFileSync('contracts/test/MyToken.t.sol', 'utf8')
+            expect(forgeTest).to.contain('contract MyTokenTest is DSTest')
+            expect(forgeTest).to.contain('import { MyToken } from "../MyToken.sol";')
+            expect(forgeTest).to.not.contain('MockERC20')
+        })
+
+        it('leaves the registry-name files untouched when no rename is requested', async function () {
+            await buildMockContract('MockERC20')
+
+            expect(fs.existsSync('contracts/MockERC20.sol')).to.equal(true)
+            expect(fs.existsSync('contracts/MyToken.sol')).to.equal(false)
+        })
+
+        it('keeps the camelCase identifier consistent across artifacts', async function () {
+            await buildMockContract('MockERC20', renameOptions)
+            await buildMockDeploymentScriptOrTest('MockERC20', 'deployment', renameOptions)
+            await buildMockDeploymentScriptOrTest('MockERC20', 'test', renameOptions)
+
+            const deployScript = fs.readFileSync('scripts/deploy-my-token.ts', 'utf8')
+            const hardhatTest = fs.readFileSync('test/test-my-token.ts', 'utf8')
+
+            expect(deployScript).to.contain('const myToken =')
+            expect(hardhatTest).to.contain('let myToken:')
+        })
+    })
 })

--- a/test/renameMockContract.test.ts
+++ b/test/renameMockContract.test.ts
@@ -1,0 +1,129 @@
+import { expect } from 'chai'
+
+import {
+    formatAddCustomMockContractFlag,
+    parseAddCustomMockContractFlag
+} from '../src/serveInquirer.ts'
+import {
+    inheritanceConflicts,
+    isValidSolidityIdentifier,
+    validateRename
+} from '../src/renameMockContract.ts'
+import MockContractsList from '../src/mockContracts/index.ts'
+
+/**
+ * Unit tests for the rename validators. Issue #167.
+ *
+ * These cover the pure validators that gate the rename prompts in the
+ * interactive flow and the `--addCustomMockContract` CLI flag. The
+ * file-IO behaviour of `buildMockContract` / `buildMockDeploymentScriptOrTest`
+ * with the new options is covered in `buildMockContracts.test.ts`.
+ */
+describe('renameMockContract (issue #167)', function () {
+    describe('isValidSolidityIdentifier', function () {
+        const validNames = ['MyToken', 'MyToken42', '_MyToken', 'token', 'TOKEN_2']
+        for (const name of validNames) {
+            it(`accepts ${name}`, function () {
+                expect(isValidSolidityIdentifier(name)).to.equal(true)
+            })
+        }
+
+        const invalidNames = [
+            '1Token',
+            'My-Token',
+            'My Token',
+            'My.Token',
+            '',
+            'contract',
+            'function',
+            'let',
+            'const',
+            'var',
+            'true',
+            'false',
+            'uint256'
+        ]
+        for (const name of invalidNames) {
+            it(`rejects ${JSON.stringify(name)}`, function () {
+                expect(isValidSolidityIdentifier(name)).to.equal(false)
+            })
+        }
+    })
+
+    describe('inheritanceConflicts', function () {
+        const mockERC20 = MockContractsList.find((entry) => entry.name === 'MockERC20')!
+        const mockERC20Upgradeable = MockContractsList.find((entry) => entry.name === 'MockERC20Upgradeable')!
+        const mockProxyAdmin = MockContractsList.find((entry) => entry.name === 'MockProxyAdmin')!
+
+        it('flags the ERC20 parent identifier', function () {
+            expect(inheritanceConflicts('ERC20', mockERC20)).to.deep.equal(['ERC20'])
+        })
+
+        it('flags the ERC721 parent identifier', function () {
+            const mockERC721 = MockContractsList.find((entry) => entry.name === 'MockERC721')!
+            expect(inheritanceConflicts('ERC721', mockERC721)).to.deep.equal(['ERC721'])
+        })
+
+        it('flags Initializable for upgradeable mocks', function () {
+            expect(inheritanceConflicts('Initializable', mockERC20Upgradeable)).to.deep.equal(['Initializable'])
+        })
+
+        it('flags ProxyAdmin for the proxy admin mock', function () {
+            expect(inheritanceConflicts('ProxyAdmin', mockProxyAdmin)).to.deep.equal(['ProxyAdmin'])
+        })
+
+        it('returns an empty list when no conflict exists', function () {
+            expect(inheritanceConflicts('MyToken', mockERC20)).to.deep.equal([])
+        })
+    })
+
+    describe('validateRename', function () {
+        const mockERC20 = MockContractsList.find((entry) => entry.name === 'MockERC20')!
+        const mockERC20Upgradeable = MockContractsList.find((entry) => entry.name === 'MockERC20Upgradeable')!
+
+        it('accepts a valid, non-conflicting name', function () {
+            expect(validateRename('MyToken', mockERC20)).to.equal(true)
+        })
+
+        it('rejects a name that clashes with an inherited identifier', function () {
+            const result = validateRename('ERC20', mockERC20)
+            expect(typeof result).to.equal('string')
+            expect(result as string).to.contain('ERC20')
+        })
+
+        it('rejects a name that clashes with Initializable for upgradeable mocks', function () {
+            const result = validateRename('Initializable', mockERC20Upgradeable)
+            expect(typeof result).to.equal('string')
+            expect(result as string).to.contain('Initializable')
+        })
+
+        it('rejects an invalid identifier with a Solidity-style hint', function () {
+            const result = validateRename('1Token', mockERC20)
+            expect(typeof result).to.equal('string')
+            expect(result as string).to.contain('reserved')
+        })
+    })
+
+    describe('--addCustomMockContract flag round-trip', function () {
+        it('round-trips a well-formed value', function () {
+            const formatted = formatAddCustomMockContractFlag('MockERC20', 'MyToken', 'MyToken', 'MOCK')
+            expect(formatted).to.equal('MockERC20:MyToken:MyToken:MOCK')
+            expect(parseAddCustomMockContractFlag(formatted)).to.deep.equal({
+                registryName: 'MockERC20',
+                customName: 'MyToken',
+                constructorName: 'MyToken',
+                constructorSymbol: 'MOCK'
+            })
+        })
+
+        it('rejects a value with the wrong number of segments', function () {
+            expect(parseAddCustomMockContractFlag('MockERC20:MyToken')).to.equal(undefined)
+            expect(parseAddCustomMockContractFlag('MockERC20:MyToken:MyToken:MOCK:extra')).to.equal(undefined)
+        })
+
+        it('rejects undefined and empty inputs', function () {
+            expect(parseAddCustomMockContractFlag(undefined)).to.equal(undefined)
+            expect(parseAddCustomMockContractFlag('')).to.equal(undefined)
+        })
+    })
+})


### PR DESCRIPTION
Closes #167

## Summary

- Add `src/renameMockContract.ts` with `isValidSolidityIdentifier`,
  `inheritanceConflicts`, and `validateRename` so malformed names and
  inheritance clashes (`ERC20`, `Initializable`, `ProxyAdmin`, …) are
  rejected before any artifact is written.
- Extend `buildMockContract` / `buildMockDeploymentScriptOrTest` with an
  `IRenameOptions` argument (`customName` + `constructorArgs`). A pure
  `renderMockTemplate` helper walks the template line-by-line and
  rewrites the registry identifier, its camelCase variant, the upgradeable
  `__<Name>_init` helpers, and the constructor literals — anchored on
  the OpenZeppelin parent call (`ERC20(...)`, `ERC721(...)`,
  `__<Name>_init(...)`) so unrelated `describe('MockERC20', ...)` titles
  fall through to the identifier rename.
- `serveMockContractCreatorSelector` now prompts for a custom contract
  name (defaulting to the registry name) plus constructor name and symbol
  before writing each artifact, and prints the equivalent CLI command.
- Add a `--addCustomMockContract` flag to `serveCli` shaped as
  `<registryName>:<customName>:<constructorName>:<constructorSymbol>`
  so the same flow is reachable non-interactively.
- README documents the new prompts and the CLI flag.

## Verification

- `npm run lint` — clean.
- `npm test` — 208 passing (was 172; +36 new asserts).
- `npm run build` — clean.

## Files

- `src/renameMockContract.ts` (new) — validators.
- `src/buildMockContracts.ts` — rename renderer + per-artifact path routing.
- `src/serveInquirer.ts` — rename prompts + `--addCustomMockContract` flag.
- `test/renameMockContract.test.ts` (new), `test/buildMockContracts.test.ts` —
  validator and rename-path coverage.
- `README.md` — document the rename flow.