### PR TITLE
docs(readme): fix typos and trim redundant 'Directories' section (closes #173)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,21 +95,11 @@ export default defineConfig({
 
 ## Directories
 
--   [src/](./src/)
--   [test/](./test/)
-
--   [.mocharc.json](./.mocharc.json)
--   [.npmignore](./.npmignore)
--   [.prettierignore](./.prettierignore)
--   [.prettierrc](./.prettierrc)
--   [awesome-readme.config.js](./awesome-readme.config.js)
--   [CONTRIBUTING.md](./CONTRIBUTING.md)
--   [eslint.config.js](./eslint.config.js)
--   [LICENSE](./LICENSE)
--   [package-lock.json](./package-lock.json)
--   [package.json](./package.json)
--   [tsconfig.json](./tsconfig.json)
--   [tsconfig.prod.json](./tsconfig.prod.json)
+> See the [Directory Tree](#directory-tree) below for the full layout of the
+> repo. The CLI source is split between [`src/`](./src/) (menus, helpers,
+> plugin entry) and [`src/mockContracts/`](./src/mockContracts/) (template
+> Solidity, deploy scripts and tests used by `npx hardhat cli`). Tests live in
+> [`test/`](./test/).
 
 ## CLI features
 

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ export default defineConfig({
 
 ## CLI features
 
--   Run tests (Allow you you to run tests on all files or specific files in test/)
--   Run scripts (Allow you you to run scripts on specific files in scripts/)
--   Select scripts and tests to run (Allow you to select a script to execute and all or one test to perform afterward)
+-   Run tests (run all test files or a specific file under `test/`)
+-   Run scripts (run a specific script or every file under `scripts/`)
+-   Select scripts and tests to run (pick a script to execute and run all tests or one test after it)
 -   Flatten all your contract or a specific contract (offer to rename SPDX-License-Identifier -> SPDX-License-Flatten-Identifier to avoid multiple license identifier issue)
 -   Run Forge test on all or single test contracts if forge setting is detected
 -   Run coverage tests (Available only if solidity-coverage is installed and available as a task)
@@ -423,7 +423,7 @@ Return:
     deployer: string
     deploymentDate: Date
     chainId: number
-    blockHah?: string
+    blockHash?: string
     blockNumber?: number
     tag?: string
     extra?: any
@@ -477,7 +477,7 @@ Return:
         deployer: string
         deploymentDate: Date
         chainId: number
-        blockHah?: string
+        blockHash?: string
         blockNumber?: number
         tag?: string
         extra?: any
@@ -581,7 +581,7 @@ Return (also printed as a table with `console.table`):
 - Setup chains, RPC and accounts:
     - Activate/Disable chain to show on test/scripts options
     - Build .env file with rpc url and private key (or mnemonic)
-    - Add ".env.hardhat-awesome-cli" to .gitignore amd .npmignore (create .gitignore if do detected)
+    - Add ".env.hardhat-awesome-cli" to .gitignore and .npmignore (create .gitignore if not detected)
     - See all config for activated chain
     - Create Github test workflows
     - Create Foundry settings, remapping and test utilities


### PR DESCRIPTION
Closes #173

Two focused commits on `README.md`:

1. **fix typos** (`fee34ab`)
   - Three 'Allow you you' duplications in the CLI features overview.
   - Two `blockHah` -> `blockHash` typos in the address-book return
     examples (matches the field used in `src/AwesomeAddressBook.ts`).
   - `amd` -> `and` and `do detected` -> `not detected` in the
     duplicate '💪 Done' details section.

2. **trim the redundant 'Directories' section** (`4981001`)
   - The top-level flat file list duplicated the 'Directory Tree'
     rendered near the bottom of the README. Replace it with a short
     pointer to the deep reference so the first screen stays focused on
     the HH3 install / quick start steps.

Acceptance criteria from #173:
- [x] New user can install on HH3 from the top of the README alone
  (install section already lives at the top; no change needed).
- [x] Known typos fixed.
- [x] Deep reference still reachable without dominating the first screen
  ('Directory Tree' anchor is one click away from the trimmed pointer).
