### PR TITLE
chore(release): adopt Changesets for releases and add CHANGELOG

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,25 @@
+# Changesets
+
+This folder holds [Changesets](https://github.com/changesets/changesets) for `hardhat-awesome-cli`.
+
+## Contributor workflow
+
+1. Make your change on a feature branch.
+2. Add a new file under `.changeset/` (e.g. `my-change.md`) with:
+   ```md
+   ---
+   "hardhat-awesome-cli": minor
+   ---
+
+   Short, user-facing description of the change.
+   ```
+   Use `major` for breaking changes, `minor` for new features, `patch` for
+   bug fixes and chores.
+3. Open the PR. CI does not fail on missing changesets — the maintainer
+   triages them on merge.
+4. On merge to `main`, the release workflow opens a "Version Packages" PR
+   that bumps `package.json`, updates `CHANGELOG.md`, and removes the
+   consumed changesets. Merging that PR cuts the GitHub Release and
+   publishes to npm.
+
+See `CONTRIBUTING.md` for the full contribution guide.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.changeset/release-automation.md
+++ b/.changeset/release-automation.md
@@ -1,0 +1,5 @@
+---
+"hardhat-awesome-cli": minor
+---
+
+Add a `CHANGELOG.md` and adopt [Changesets](https://github.com/changesets/changesets) for version bumps, GitHub Releases, and npm publishing. Contributors now ship a `.changeset/*.md` entry on each PR; the release workflow opens a "Version Packages" PR automatically and publishes on merge to `main`. See `CONTRIBUTING.md` for the new flow.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+# Drives version bumps, GitHub Releases, and npm publishes via Changesets.
+# On every push to `main`:
+#   1. If there are pending changesets, changesets/action opens or updates a
+#      "Version Packages" PR that bumps `package.json` and rewrites
+#      `CHANGELOG.md`.
+#   2. When that PR merges, the same action publishes the new version to
+#      npm and creates a GitHub Release.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Version Packages & Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org/
+      - name: NPM Clean Install
+        run: npm ci
+      - name: Run changesets
+        uses: changesets/action@v1
+        with:
+          publish: npm run build && npm publish
+          commit: "chore(release): version packages"
+          title: "chore(release): version packages"
+          summary: "Bumps versions, updates CHANGELOG, and publishes."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,123 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- CHANGELOG and release automation via [Changesets](https://github.com/changesets/changesets).
+  Contributors now add a `.changeset/*.md` entry on each PR; the Version Packages
+  PR opens automatically and a GitHub Release + npm publish happen on merge to
+  `main`. `CONTRIBUTING.md` no longer requires manual `package.json` version bumps.
+- New GitHub Actions workflow `.github/workflows/release.yml` that runs the
+  Changesets publish action on every push to `main`.
+
+## [0.1.6] - 2026-07-28
+
+### Changed
+
+- Mock contract generator: dropped the `MockProxyAdmin` / `TransparentUpgradeableProxy`
+  TODO items now that the templates are in place.
+- Reformat plugin and test fixtures with Prettier.
+
+### Added
+
+- Foundry tests for `MockProxyAdmin` and `MockTransparentUpgradeableProxy`.
+- Generator test that iterates `MockContractsList` and asserts every entry's
+  artifacts exist on disk.
+- Extended ERC20 / ERC721 / ERC1155 template tests with mint, burn, transfer,
+  and approval coverage.
+- Coverage reporting via `c8`, surfaced as a CI artifact.
+
+## [0.1.5] - 2026-07-13
+
+### Added
+
+- Hardhat 3 support: typed plugin entry, augmented `paths.cli`, and a
+  consumer smoke test (`npm run smoke`) that packs the package, installs
+  it into a clean HH3 fixture, and asserts the `cli` task loads.
+- Discrete TypeScript types across the inquirer flows (`IAddressBookConfig`,
+  `IHreContext`, tightened `config` and `address-book` typing).
+- CI lint and build jobs running on every push to `main` and on pull requests.
+- Renamed `Mock-VRFCoordinatorV2Mock` to `MockVRFCoordinatorV2Mock` for
+  naming consistency.
+- Mock contract rename flow: prompt for a custom name + constructor args and
+  expose it as the `--addCustomMockContract` CLI flag.
+
+### Fixed
+
+- Hardhat config mutation is now safe across plugin re-runs.
+- `getEnvValue` returns the parsed env value, not the function itself.
+- `addressBook` access is qualified in the Transparent Upgradeable Proxy
+  deploy script.
+- Published `bin` points at the compiled `dist` entry instead of the source.
+- Removed a stub `fs` dependency that was no longer needed.
+- Dropped `tslint` in favour of ESLint across the project.
+- Secrets hygiene: private keys and mnemonics are masked when the active
+  config is displayed.
+- Removed fixed multi-second `sleep()` calls in favour of the
+  `AWESOME_CLI_NO_PAUSE` / `AWESOME_CLI_PAUSE_MS` env knobs.
+
+## [0.1.4] - 2026-06-29
+
+### Added
+
+- Mock-proxy Admin and Transparent Upgradeable Proxy templates.
+- Function selector listing for contracts.
+
+### Fixed
+
+- Hardhat 3 plugin list and registration.
+
+## [0.1.3] - 2026-05-20
+
+### Changed
+
+- Pinned peer dependency to Hardhat `^3.0.0`.
+- Migrated tooling to TypeScript 7 and Node 24.
+
+### Fixed
+
+- Resolved `inquirer` v14 type breaks and `eslint` v10 config migration.
+
+## [0.1.2] - 2026-04-12
+
+### Added
+
+- Directory-level exclusions in the settings file and the matching
+  `--exclude-*-directory` CLI flags.
+
+### Fixed
+
+- Address-book imports honour the saved network name.
+
+## [0.1.1] - 2026-03-04
+
+### Added
+
+- `package.json` `pnpm` and `bun` install detection with the matching
+  workflow YAMLs.
+
+### Fixed
+
+- Allow `--addAllMockContracts` to skip prompts when all defaults are accepted.
+
+## [0.1.0] - 2026-02-08
+
+### Added
+
+- First public release of the interactive CLI plugin: environment builder,
+  networks, mock contracts, workflows, plugins, and an address book.
+
+[Unreleased]: https://github.com/marc-aurele-besner/hardhat-awesome-cli/compare/v0.1.6...HEAD
+[0.1.6]: https://github.com/marc-aurele-besner/hardhat-awesome-cli/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.com/marc-aurele-besner/hardhat-awesome-cli/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/marc-aurele-besner/hardhat-awesome-cli/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/marc-aurele-besner/hardhat-awesome-cli/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/marc-aurele-besner/hardhat-awesome-cli/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/marc-aurele-besner/hardhat-awesome-cli/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/marc-aurele-besner/hardhat-awesome-cli/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,32 @@ npm run build
 
 3. Document the new features, or functionality in README.md
 
-4. Increase the version numbers in package.json to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+4. Add a [Changeset](https://github.com/changesets/changesets) entry that describes the change from a user's perspective. From the repo root, run `npm run changeset` and follow the prompts — this drops a Markdown file under `.changeset/` that the release workflow consumes. Use:
+
+   - `major` for breaking changes
+   - `minor` for new features
+   - `patch` for bug fixes and chores
+
+   The maintainer triages changesets on merge; you don't need to bump
+   `package.json` or `CHANGELOG.md` by hand. The release workflow opens a
+   "Version Packages" PR that does both, and publishes to npm + creates a
+   GitHub Release when it merges.
+
+## Release process (maintainers)
+
+Releases are fully automated by `.github/workflows/release.yml` (powered by
+`changesets/action`). On every push to `main`:
+
+1. If any `.changeset/*.md` files exist, the action opens or updates a
+   "Version Packages" PR that runs `changeset version` — bumping
+   `package.json`, rewriting `CHANGELOG.md`, and deleting the consumed
+   changesets.
+2. Merging that PR triggers the same action. With no changesets pending,
+   it publishes the new version to npm (`npm run build && npm publish`,
+   which uses the `prepublishOnly` hook) and creates a GitHub Release.
+
+Required repo secrets: `NPM_TOKEN` (an npm automation token with publish
+rights on `hardhat-awesome-cli`).
 
 ## Code of Conduct
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
             "devDependencies": {
                 "@babel/core": "^8.0.0",
                 "@babel/eslint-parser": "^8.0.0",
+                "@changesets/cli": "^2.31.1",
                 "@eslint/js": "^10.0.0",
                 "@types/chai": "^5.0.0",
                 "@types/inquirer": "^9.0.3",
@@ -360,6 +361,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@babel/runtime": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+            "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@bcoe/v8-coverage": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
@@ -368,6 +379,302 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@changesets/apply-release-plan": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.1.tgz",
+            "integrity": "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/config": "^3.1.4",
+                "@changesets/get-version-range-type": "^0.4.0",
+                "@changesets/git": "^3.0.4",
+                "@changesets/should-skip-package": "^0.1.2",
+                "@changesets/types": "^6.1.0",
+                "@manypkg/get-packages": "^1.1.3",
+                "detect-indent": "^6.0.0",
+                "fs-extra": "^7.0.1",
+                "lodash.startcase": "^4.4.0",
+                "outdent": "^0.5.0",
+                "prettier": "^2.7.1",
+                "resolve-from": "^5.0.0",
+                "semver": "^7.5.3"
+            }
+        },
+        "node_modules/@changesets/apply-release-plan/node_modules/prettier": {
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/@changesets/assemble-release-plan": {
+            "version": "6.0.10",
+            "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.10.tgz",
+            "integrity": "sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/errors": "^0.2.0",
+                "@changesets/get-dependents-graph": "^2.1.4",
+                "@changesets/should-skip-package": "^0.1.2",
+                "@changesets/types": "^6.1.0",
+                "@manypkg/get-packages": "^1.1.3",
+                "semver": "^7.5.3"
+            }
+        },
+        "node_modules/@changesets/changelog-git": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz",
+            "integrity": "sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/types": "^6.1.0"
+            }
+        },
+        "node_modules/@changesets/cli": {
+            "version": "2.31.1",
+            "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.31.1.tgz",
+            "integrity": "sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/apply-release-plan": "^7.1.1",
+                "@changesets/assemble-release-plan": "^6.0.10",
+                "@changesets/changelog-git": "^0.2.1",
+                "@changesets/config": "^3.1.4",
+                "@changesets/errors": "^0.2.0",
+                "@changesets/get-dependents-graph": "^2.1.4",
+                "@changesets/get-release-plan": "^4.0.16",
+                "@changesets/git": "^3.0.4",
+                "@changesets/logger": "^0.1.1",
+                "@changesets/pre": "^2.0.2",
+                "@changesets/read": "^0.6.7",
+                "@changesets/should-skip-package": "^0.1.2",
+                "@changesets/types": "^6.1.0",
+                "@changesets/write": "^0.4.0",
+                "@inquirer/external-editor": "^1.0.2",
+                "@manypkg/get-packages": "^1.1.3",
+                "ansi-colors": "^4.1.3",
+                "enquirer": "^2.4.1",
+                "fs-extra": "^7.0.1",
+                "mri": "^1.2.0",
+                "package-manager-detector": "^0.2.0",
+                "picocolors": "^1.1.0",
+                "resolve-from": "^5.0.0",
+                "semver": "^7.5.3",
+                "spawndamnit": "^3.0.1",
+                "term-size": "^2.1.0"
+            },
+            "bin": {
+                "changeset": "bin.js"
+            }
+        },
+        "node_modules/@changesets/cli/node_modules/@inquirer/external-editor": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+            "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chardet": "^2.1.1",
+                "iconv-lite": "^0.7.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@changesets/config": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.4.tgz",
+            "integrity": "sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/errors": "^0.2.0",
+                "@changesets/get-dependents-graph": "^2.1.4",
+                "@changesets/logger": "^0.1.1",
+                "@changesets/should-skip-package": "^0.1.2",
+                "@changesets/types": "^6.1.0",
+                "@manypkg/get-packages": "^1.1.3",
+                "fs-extra": "^7.0.1",
+                "micromatch": "^4.0.8"
+            }
+        },
+        "node_modules/@changesets/errors": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
+            "integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "extendable-error": "^0.1.5"
+            }
+        },
+        "node_modules/@changesets/get-dependents-graph": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.4.tgz",
+            "integrity": "sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/types": "^6.1.0",
+                "@manypkg/get-packages": "^1.1.3",
+                "picocolors": "^1.1.0",
+                "semver": "^7.5.3"
+            }
+        },
+        "node_modules/@changesets/get-release-plan": {
+            "version": "4.0.16",
+            "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.16.tgz",
+            "integrity": "sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/assemble-release-plan": "^6.0.10",
+                "@changesets/config": "^3.1.4",
+                "@changesets/pre": "^2.0.2",
+                "@changesets/read": "^0.6.7",
+                "@changesets/types": "^6.1.0",
+                "@manypkg/get-packages": "^1.1.3"
+            }
+        },
+        "node_modules/@changesets/get-version-range-type": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
+            "integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@changesets/git": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz",
+            "integrity": "sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/errors": "^0.2.0",
+                "@manypkg/get-packages": "^1.1.3",
+                "is-subdir": "^1.1.1",
+                "micromatch": "^4.0.8",
+                "spawndamnit": "^3.0.1"
+            }
+        },
+        "node_modules/@changesets/logger": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz",
+            "integrity": "sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picocolors": "^1.1.0"
+            }
+        },
+        "node_modules/@changesets/parse": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.3.tgz",
+            "integrity": "sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/types": "^6.1.0",
+                "js-yaml": "^4.1.1"
+            }
+        },
+        "node_modules/@changesets/pre": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz",
+            "integrity": "sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/errors": "^0.2.0",
+                "@changesets/types": "^6.1.0",
+                "@manypkg/get-packages": "^1.1.3",
+                "fs-extra": "^7.0.1"
+            }
+        },
+        "node_modules/@changesets/read": {
+            "version": "0.6.7",
+            "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.7.tgz",
+            "integrity": "sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/git": "^3.0.4",
+                "@changesets/logger": "^0.1.1",
+                "@changesets/parse": "^0.4.3",
+                "@changesets/types": "^6.1.0",
+                "fs-extra": "^7.0.1",
+                "p-filter": "^2.1.0",
+                "picocolors": "^1.1.0"
+            }
+        },
+        "node_modules/@changesets/should-skip-package": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz",
+            "integrity": "sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/types": "^6.1.0",
+                "@manypkg/get-packages": "^1.1.3"
+            }
+        },
+        "node_modules/@changesets/types": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz",
+            "integrity": "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@changesets/write": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz",
+            "integrity": "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@changesets/types": "^6.1.0",
+                "fs-extra": "^7.0.1",
+                "human-id": "^4.1.1",
+                "prettier": "^2.7.1"
+            }
+        },
+        "node_modules/@changesets/write/node_modules/prettier": {
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -1430,6 +1737,134 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@manypkg/find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.5.5",
+                "@types/node": "^12.7.1",
+                "find-up": "^4.1.0",
+                "fs-extra": "^8.1.0"
+            }
+        },
+        "node_modules/@manypkg/find-root/node_modules/@types/node": {
+            "version": "12.20.55",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@manypkg/find-root/node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@manypkg/find-root/node_modules/fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
+        "node_modules/@manypkg/find-root/node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@manypkg/find-root/node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@manypkg/find-root/node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@manypkg/get-packages": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
+            "integrity": "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.5.5",
+                "@changesets/types": "^4.0.1",
+                "@manypkg/find-root": "^1.1.0",
+                "fs-extra": "^8.1.0",
+                "globby": "^11.0.0",
+                "read-yaml-file": "^1.1.0"
+            }
+        },
+        "node_modules/@manypkg/get-packages/node_modules/@changesets/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@manypkg/get-packages/node_modules/fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
         "node_modules/@noble/curves": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
@@ -1454,6 +1889,44 @@
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/@nomicfoundation/edr": {
@@ -2296,6 +2769,16 @@
             "dev": true,
             "license": "Python-2.0"
         },
+        "node_modules/array-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/assertion-error": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2353,6 +2836,19 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/better-path-resolve": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
+            "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-windows": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/brace-expansion": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
@@ -2374,6 +2870,19 @@
             "license": "MIT",
             "engines": {
                 "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/browser-stdout": {
@@ -2851,6 +3360,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/detect-indent": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+            "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/diff": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
@@ -2859,6 +3378,19 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
+            }
+        },
+        "node_modules/dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-type": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/dotenv": {
@@ -3118,6 +3650,20 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/esquery": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -3177,6 +3723,13 @@
                 "@scure/bip39": "1.3.0"
             }
         },
+        "node_modules/extendable-error": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
+            "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3192,6 +3745,36 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/fast-glob": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fast-glob/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/fast-json-stable-stringify": {
@@ -3232,6 +3815,16 @@
                 "fast-string-width": "^3.0.2"
             }
         },
+        "node_modules/fastq": {
+            "version": "1.20.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
         "node_modules/figlet": {
             "version": "1.11.4",
             "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.11.4.tgz",
@@ -3259,6 +3852,19 @@
             },
             "engines": {
                 "node": ">=16.0.0"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/find-up": {
@@ -3324,6 +3930,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
             }
         },
         "node_modules/fsevents": {
@@ -3448,6 +4069,34 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/globby": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.2.9",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/hardhat": {
             "version": "3.11.1",
             "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-3.11.1.tgz",
@@ -3504,6 +4153,16 @@
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/human-id": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.2.0.tgz",
+            "integrity": "sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "human-id": "dist/cli.js"
+            }
         },
         "node_modules/iconv-lite": {
             "version": "0.7.3",
@@ -3610,6 +4269,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
         "node_modules/is-path-inside": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -3630,6 +4299,19 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-subdir": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
+            "integrity": "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "better-path-resolve": "1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/is-unicode-supported": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -3641,6 +4323,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/isexe": {
@@ -3785,6 +4477,16 @@
                 "node": ">=6"
             }
         },
+        "node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "dev": true,
+            "license": "MIT",
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
         "node_modules/keyv": {
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3824,6 +4526,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/lodash.startcase": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+            "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
@@ -3866,6 +4575,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/micro-eth-signer": {
@@ -3930,6 +4649,20 @@
             "license": "MIT",
             "funding": {
                 "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
             }
         },
         "node_modules/minimatch": {
@@ -4037,6 +4770,16 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
+        "node_modules/mri": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4102,6 +4845,36 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/outdent": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
+            "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/p-filter": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+            "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-map": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/p-filter/node_modules/p-map": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+            "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4147,12 +4920,32 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
             "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
             "dev": true,
             "license": "BlueOak-1.0.0"
+        },
+        "node_modules/package-manager-detector": {
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
+            "integrity": "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "quansync": "^0.2.7"
+            }
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
@@ -4198,12 +4991,45 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/pify": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
@@ -4241,6 +5067,44 @@
                 "node": ">=6"
             }
         },
+        "node_modules/quansync": {
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+            "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/antfu"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/sxzz"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -4249,6 +5113,46 @@
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "^5.1.0"
+            }
+        },
+        "node_modules/read-yaml-file": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
+            "integrity": "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.1.5",
+                "js-yaml": "^3.6.1",
+                "pify": "^4.0.1",
+                "strip-bom": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/read-yaml-file/node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/read-yaml-file/node_modules/js-yaml": {
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/readdirp": {
@@ -4275,6 +5179,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/resolve.exports": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
@@ -4283,6 +5197,17 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/reusify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
             }
         },
         "node_modules/rfdc": {
@@ -4299,6 +5224,30 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
             }
         },
         "node_modules/rxjs": {
@@ -4395,6 +5344,34 @@
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
+        },
+        "node_modules/slash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/spawndamnit": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
+            "integrity": "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE",
+            "dependencies": {
+                "cross-spawn": "^7.0.5",
+                "signal-exit": "^4.0.1"
+            }
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/string-width": {
             "version": "5.1.2",
@@ -4493,6 +5470,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4517,6 +5504,19 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/term-size": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+            "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/test-exclude": {
@@ -4567,6 +5567,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
             }
         },
         "node_modules/tslib": {
@@ -4659,6 +5672,16 @@
             "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
             "devOptional": true,
             "license": "MIT"
+        },
+        "node_modules/universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
         },
         "node_modules/update-browserslist-db": {
             "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -43,11 +43,14 @@
         "prepublishOnly": "tsc --project tsconfig.prod.json",
         "build": "tsc --project tsconfig.prod.json",
         "buidl": "tsc",
-        "watch": "tsc -w"
+        "watch": "tsc -w",
+        "changeset": "changeset",
+        "version-packages": "changeset version"
     },
     "devDependencies": {
         "@babel/core": "^8.0.0",
         "@babel/eslint-parser": "^8.0.0",
+        "@changesets/cli": "^2.31.1",
         "@eslint/js": "^10.0.0",
         "@types/chai": "^5.0.0",
         "@types/inquirer": "^9.0.3",


### PR DESCRIPTION
## Summary

Closes #174.

Introduces a Keep a Changelog-style `CHANGELOG.md` and adopts [Changesets](https://github.com/changesets/changesets) for version bumps, GitHub Releases, and npm publishing. The new release workflow opens or updates a "Version Packages" PR on every push to `main`; merging that PR publishes to npm and creates a GitHub Release.

`CONTRIBUTING.md` now asks contributors to add a `.changeset/*.md` entry on each PR instead of bumping `package.json` by hand. The maintainer triages changesets on merge.

## What changed

- **`CHANGELOG.md`** — Keep a Changelog format, retroactively summarizing 0.1.0–0.1.6 from the git history. The `[Unreleased]` section captures the changesets adoption itself.
- **`.changeset/`** — `config.json` (public semver, base branch `main`), a `README.md` explaining the contributor flow, and an initial `release-automation.md` changeset describing the new process.
- **`.github/workflows/release.yml`** — runs `changesets/action@v1` on every push to `main`, with `npm run build && npm publish` for the publish step. The `prepublishOnly` `tsc` step stays in place.
- **`CONTRIBUTING.md`** — replaces the "bump `package.json`" step with `npm run changeset`, and adds a "Release process (maintainers)" section. The new repo secret is `NPM_TOKEN` (npm automation token with publish rights).
- **`package.json`** — adds `@changesets/cli` `^2.31.1` as a devDependency and two scripts: `changeset` (add a new entry) and `version-packages` (run `changeset version` locally).

## Verification

- `npm run lint` — clean
- `npm run build` — clean
- `npm test` — 208 passing
- `npx changeset status` — recognizes the pending `release-automation.md` changeset and reports `hardhat-awesome-cli` will bump at `minor`

## Required for the maintainer

After merging this PR, head to repo Settings → Secrets → Actions and add `NPM_TOKEN` with publish rights on `hardhat-awesome-cli`. The first "Version Packages" PR will be opened automatically on the next push to `main` that includes a changeset.