### PR TITLE
feat: scaffold deployment script for any contract (closes #166)

### DIFF
--- a/.changeset/deployment-contract-generator.md
+++ b/.changeset/deployment-contract-generator.md
@@ -1,0 +1,5 @@
+---
+"hardhat-awesome-cli": minor
+---
+
+Add a `Create deployment scripts` menu and matching `--addDeploymentScript <ContractName>[:arg1:arg2:...]` flag that scaffold `scripts/deploy-<Name>.{ts,js}` for any contract in `contracts/`. The generated script imports `addressBook` from `hardhat`, deploys the contract (forwarding any constructor arguments) and writes the deployed address to `contractsAddressDeployed.json`. The `scripts/` directory is created on demand and the generator refuses to overwrite an existing `deploy-<Name>.{ts,js}`. Closes #166.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,30 @@ export default defineConfig({
     Hitting Enter at every interactive prompt keeps the registry defaults
     so existing users stay on the stock `MockERC20` flow.
 
+-   Create deployment scripts (issue #166) — pick an existing contract from
+    `contracts/` and the CLI scaffolds `scripts/deploy-<Name>.ts` (or `.js`
+    when the project ships a `hardhat.config.js`). The generated script
+    imports `addressBook` from `hardhat`, deploys the contract, and calls
+    `addressBook.saveContract(...)` so the address lands in
+    `contractsAddressDeployed.json` without further edits. Constructor
+    arguments are forwarded to `<Contract>.deploy(...)` so the file is
+    ready to run with `npx hardhat run scripts/deploy-<Name>.ts
+    --network <network>`.
+
+    The CLI prints the equivalent command for scripting — the same
+    generator is reachable without prompts via:
+
+    ```bash
+    npx hardhat cli --addDeploymentScript MyToken
+    ```
+
+    Constructor arguments can be supplied as `:`-separated segments after
+    the contract name, e.g.
+    `npx hardhat cli --addDeploymentScript MyToken:0xToken:42`. The `scripts/`
+    directory is created on demand if it does not exist, and the generator
+    refuses to overwrite an existing `deploy-<Name>.{ts,js}` so the
+    consumer can rename or delete the old file before re-running.
+
 -   Get account balance
 
 ### Current chain support
@@ -255,6 +279,7 @@ and yarn templates.
 ## CLI optional flags
 
 -   --add-activated-chain Add chains from the chain selection (default: "")
+-   --add-deployment-script Scaffold a deployment script for the named contract. Pass the contract name, optionally followed by ":"-separated constructor arguments, e.g. "<ContractName>:<arg1>:<arg2>". (default: "")
 -   --add-foundry Create Foundry settings, remapping and test utilities (default: "")
 -   --add-foundry-test-utility Install the foundry-test-utility npm package and add its remapping (default: "")
 -   --add-github-test-workflow Create Github test workflows (default: "")

--- a/src/buildDeploymentContract.ts
+++ b/src/buildDeploymentContract.ts
@@ -1,0 +1,194 @@
+import fs from 'fs'
+
+import { transformTsToJs } from './utils.ts'
+
+/**
+ * Optional inputs accepted by `buildDeploymentContract`.
+ *
+ * `customName` overrides the contract identifier used throughout the
+ * generated script. `constructorArgs` is forwarded to
+ * `<Contract>.deploy(...constructorArgs)` so the consumer does not need to
+ * hand-edit the script after generation.
+ *
+ * Both fields are optional. When omitted the generator still produces a
+ * working script — the consumer can edit the generated file to call
+ * `.deploy(...)` with their own arguments.
+ */
+export interface IDeploymentContractOptions {
+    customName?: string
+    constructorArgs?: string[]
+}
+
+/**
+ * TypeScript template the generator renders into `scripts/deploy-<Name>.ts`.
+ *
+ * Kept inline (rather than as a separate asset on disk) so the rendered
+ * script is easy to evolve alongside the rest of the source — the mock
+ * deploy templates follow the same pattern.
+ *
+ * The placeholders the renderer substitutes are:
+ *   `__CONTRACT_NAME__` — PascalCase contract identifier used everywhere
+ *     the script touches the contract (`getContractFactory`, `const X =`,
+ *     `saveContract`).
+ *   `__CAMEL_NAME__` — camelCase local variable (mirrors the mock deploy
+ *     script's `mockERC20` style).
+ *   `__CONSTRUCTOR_ARGS__` — comma-separated argument list passed to
+ *     `<Contract>.deploy(...)` (empty string when no args supplied).
+ */
+const DEPLOY_SCRIPT_TEMPLATE = `// @ts-ignore-next-line
+import { addressBook, ethers, network } from 'hardhat'
+
+async function main() {
+    const [deployer] = await ethers.getSigners()
+
+    const __CONTRACT_NAME__ = await ethers.getContractFactory('__CONTRACT_NAME__')
+    const __CAMEL_NAME__ = await __CONTRACT_NAME__.deploy(__CONSTRUCTOR_ARGS__)
+
+    await __CAMEL_NAME__.deployed()
+    await addressBook.saveContract('__CONTRACT_NAME__', __CAMEL_NAME__.address, (network as any).name, deployer.address)
+
+    console.log('__CONTRACT_NAME__ deployed to:', __CAMEL_NAME__.address)
+}
+
+main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+})
+`
+
+const camelCase = (name: string): string => {
+    if (name.length === 0) return name
+    return name[0].toLowerCase() + name.slice(1)
+}
+
+/**
+ * Render the deploy-script template with the contract name and constructor
+ * arguments the user supplied.
+ *
+ * Pulled out of `buildDeploymentContract` so it can be unit-tested without
+ * touching the filesystem — `renderDeploymentScript` is a pure string
+ * transform that mirrors `renderMockTemplate` in `buildMockContracts.ts`.
+ */
+export const renderDeploymentScript = (options: IDeploymentContractOptions): string => {
+    const contractName = options.customName ?? ''
+    const camelName = camelCase(contractName)
+    const constructorArgs = (options.constructorArgs ?? []).join(', ')
+    return DEPLOY_SCRIPT_TEMPLATE.replace(/__CONTRACT_NAME__/g, contractName)
+        .replace(/__CAMEL_NAME__/g, camelName)
+        .replace(/__CONSTRUCTOR_ARGS__/g, constructorArgs)
+}
+
+/**
+ * Pick the file extension that matches the consumer project's Hardhat config.
+ *
+ * Templates ship as TypeScript (the single source of truth, see #159). When
+ * the consumer uses `hardhat.config.js` we still want to write a `.js` file,
+ * so the JS variant is generated from the TS template at write time.
+ */
+const pickArtifactExtension = (): 'ts' | 'js' => {
+    if (fs.existsSync('hardhat.config.ts')) return 'ts'
+    if (fs.existsSync('hardhat.config.js')) return 'js'
+    // No Hardhat config present — fall back to TS, which is the canonical
+    // template language and what Hardhat 3 expects.
+    return 'ts'
+}
+
+/**
+ * Resolve the kebab-cased path the deploy script is written to.
+ *
+ * Mirrors the `scripts/deploy-Mock-ERC20.ts` shape of the bundled mocks so
+ * the file appears under the same conventions the rest of the project
+ * expects. When the consumer has no `scripts/` directory we create it
+ * (closes #168).
+ */
+const resolveDeploymentScriptPath = (customName: string | undefined): { finalPath: string; kebabName: string } => {
+    const sourceName = customName ?? 'Contract'
+    const kebabName = sourceName
+        // Insert a hyphen between a lowercase/digit and an uppercase letter
+        // (e.g. `MyToken` → `my-token`, `MyERC20` → `my-erc20`).
+        .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+        .toLowerCase()
+    const extension = pickArtifactExtension()
+    const finalPath = `scripts/deploy-${kebabName}.${extension}`
+    return { finalPath, kebabName }
+}
+
+/**
+ * Scaffold a deployment script for a contract the user already authored.
+ *
+ * Use cases:
+ * - The consumer picked a contract name from the contracts listing and
+ *   wants a ready-to-run deploy script that wires `addressBook.saveContract`
+ *   into the flow (closes #166).
+ * - The CLI was launched with `--addDeploymentScript <value>` and the menu
+ *   would otherwise force the user through the inquirer prompts.
+ *
+ * Behaviour:
+ * - Creates `scripts/` when missing (`recursive: true` keeps existing
+ *   directories intact).
+ * - Refuses to overwrite an existing script with the same name — the
+ *   consumer can rename or remove the old file before re-running.
+ * - Generates a CommonJS variant when the project ships a
+ *   `hardhat.config.js`, TypeScript otherwise.
+ *
+ * Returns the path written so callers can echo the file location.
+ */
+export const buildDeploymentContract = (
+    contractName: string,
+    options: IDeploymentContractOptions = {}
+): string | undefined => {
+    if (!contractName) return undefined
+
+    const renderedTs = renderDeploymentScript({ ...options, customName: options.customName ?? contractName })
+    const { finalPath } = resolveDeploymentScriptPath(options.customName ?? contractName)
+
+    fs.mkdirSync('scripts', { recursive: true })
+
+    if (fs.existsSync(finalPath)) {
+        console.log('\x1b[33m%s\x1b[0m', 'Deployment script already exists at ' + finalPath)
+        return undefined
+    }
+
+    const extension = pickArtifactExtension()
+    const output = extension === 'js' ? transformTsToJs(renderedTs) : renderedTs
+
+    console.log('\x1b[32m%s\x1b[0m', 'Creating deployment script for ', contractName, ' at ', finalPath)
+    fs.writeFileSync(finalPath, output)
+    return finalPath
+}
+
+export default buildDeploymentContract
+
+/**
+ * Render the value consumed by `--addDeploymentScript` so the printed CLI
+ * command round-trips through `parseAddDeploymentScriptFlag`.
+ *
+ * Shape: `<contractName>:<constructorArg1>:<constructorArg2>:...`. Using
+ * `:` as the delimiter means contract names (which cannot contain it) can
+ * be passed as the first segment, and any number of constructor arguments
+ * follow. Solidity identifiers and string literals must not contain `:`
+ * without escaping, so we keep the delimiter unambiguous.
+ */
+export const formatAddDeploymentScriptFlag = (contractName: string, constructorArgs: string[] = []): string => {
+    if (constructorArgs.length === 0) return contractName
+    return [contractName, ...constructorArgs].join(':')
+}
+
+/**
+ * Parse the `--addDeploymentScript` CLI flag value.
+ *
+ * Returns `undefined` when the value is empty or missing the contract name
+ * so `serveCli` can fall through to the next flag instead of silently
+ * invoking the generator with garbage.
+ */
+export const parseAddDeploymentScriptFlag = (
+    value: string | undefined
+): { contractName: string; constructorArgs: string[] } | undefined => {
+    if (typeof value !== 'string') return undefined
+    const parts = value.split(':')
+    if (parts.length === 0) return undefined
+    const [contractName, ...constructorArgs] = parts
+    if (!contractName) return undefined
+    return { contractName, constructorArgs }
+}

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -86,6 +86,12 @@ const cliTask: NewTaskDefinition = task('cli', 'Easy command line interface to u
         description: 'Get account balance',
         defaultValue: ''
     })
+    .addOption({
+        name: 'addDeploymentScript',
+        description:
+            'Scaffold a deployment script for the named contract. Pass the contract name, optionally followed by ":"-separated constructor arguments, e.g. "<ContractName>:<arg1>:<arg2>".',
+        defaultValue: ''
+    })
     // The action must be a lazy import so plugins stay load-order safe.
     .setAction(() => import('./cli-action.ts'))
     .build()

--- a/src/serveInquirer.ts
+++ b/src/serveInquirer.ts
@@ -12,6 +12,7 @@ import {
     buildTestsList
 } from './buildFilesList.ts'
 import buildFoundrySetting, { installFoundryTestUtility } from './buildFoundrySetting.ts'
+import buildDeploymentContract, { formatAddDeploymentScriptFlag, parseAddDeploymentScriptFlag } from './buildDeploymentContract.ts'
 import buildMockContract, { buildMockDeploymentScriptOrTest } from './buildMockContracts.ts'
 import {
     addActivatedChain,
@@ -896,7 +897,41 @@ const runAddCustomMockContract = async (
         await buildMockDeploymentScriptOrTest(registryName, 'testForge', options)
 }
 
-const serveDeploymentContractCreatorSelector = async () => {}
+const serveDeploymentContractCreatorSelector = async () => {
+    // Pick the contract the user wants to deploy. We reuse the contracts
+    // listing (which already excludes files the user has marked as
+    // excluded in settings) so the menu feels consistent with every other
+    // contract pick in the CLI.
+    const contractSelected = await serveFileListSelector('Select a contract to generate a deployment script for', async (subPath: string) => {
+        const contractsFilesObject = await buildContractsList(subPath)
+        return contractsFilesObject
+    })
+    if (!contractSelected || contractSelected === 'back') return
+    if (contractSelected.type !== 'file') return
+
+    // The file selector strips the `.sol` extension in its display name
+    // (see `formatFileName` in buildFilesList.ts), so the file path still
+    // carries the extension and we just take it as-is.
+    const contractName = contractSelected.filePath.replace(/\.sol$/, '')
+    const writtenPath = await buildDeploymentContract(contractName)
+    if (writtenPath) {
+        displayFinalCliCommand('addDeploymentScript', contractName)
+        await waitForReadability()
+    }
+}
+
+/**
+ * Generate a deployment script from a CLI flag (issue #166).
+ *
+ * Skips the inquirer prompts so the flag stays scriptable. The flag value
+ * is parsed via `parseAddDeploymentScriptFlag`; a malformed value aborts
+ * the operation with a yellow warning rather than throwing.
+ */
+const runAddDeploymentScript = async (contractName: string, constructorArgs: string[]): Promise<void> => {
+    const writtenPath = await buildDeploymentContract(contractName, { customName: contractName, constructorArgs })
+    if (writtenPath)
+        displayFinalCliCommand('addDeploymentScript', formatAddDeploymentScriptFlag(contractName, constructorArgs))
+}
 
 /**
  * Ethers-shaped object surface that the account-balance flow relies on.
@@ -948,6 +983,7 @@ interface ICliArgs {
     removeActivatedChain?: string
     getAccountBalance?: string
     addCustomMockContract?: string
+    addDeploymentScript?: string
 }
 
 const serveInquirer = async (env: IHreContext) => {
@@ -982,7 +1018,7 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P      'Y88P' Y8
         new inquirer.Separator(),
         // 'Deploy all contracts and run tests',
         inquirerRunMockContractCreator,
-        // 'Create deployment scripts',
+        'Create deployment scripts',
         'Get account balance',
         new inquirer.Separator(),
         inquirerFileContractsAddressDeployed,
@@ -1084,6 +1120,17 @@ const serveCli = async (args: ICliArgs, env: IHreContext) => {
                 parsed.constructorName,
                 parsed.constructorSymbol
             )
+        }
+        case isPresentString(args.addDeploymentScript): {
+            const parsed = parseAddDeploymentScriptFlag(args.addDeploymentScript)
+            if (!parsed) {
+                console.log(
+                    '\x1b[33m%s\x1b[0m',
+                    'Invalid --addDeploymentScript value. Expected "<contractName>[:<constructorArg1>:<constructorArg2>:...]".'
+                )
+                return
+            }
+            return runAddDeploymentScript(parsed.contractName, parsed.constructorArgs)
         }
         default:
             return serveInquirer(env)

--- a/test/buildDeploymentContract.test.ts
+++ b/test/buildDeploymentContract.test.ts
@@ -1,0 +1,161 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import buildDeploymentContract, {
+    formatAddDeploymentScriptFlag,
+    parseAddDeploymentScriptFlag,
+    renderDeploymentScript
+} from '../src/buildDeploymentContract.ts'
+
+/**
+ * Tests for the deployment-script generator (issue #166).
+ *
+ * Mirrors the structure of `buildMockContracts.test.ts`:
+ *   - Each test runs in its own `mkdtempSync` fixture so file-system state
+ *     does not leak between cases.
+ *   - The fixture provides a `hardhat.config.ts` so the generator picks
+ *     the TypeScript variant of the template.
+ */
+describe('buildDeploymentContract (issue #166)', function () {
+    const initialCwd = process.cwd()
+    let fixtureDirectory: string
+
+    beforeEach(function () {
+        fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-deploy-'))
+        process.chdir(fixtureDirectory)
+        fs.writeFileSync('hardhat.config.ts', 'export default {}\n')
+    })
+
+    afterEach(function () {
+        process.chdir(initialCwd)
+        fs.rmSync(fixtureDirectory, { recursive: true, force: true })
+    })
+
+    describe('renderDeploymentScript', function () {
+        it('substitutes the contract name into every identifier slot', function () {
+            const rendered = renderDeploymentScript({ customName: 'MyToken' })
+
+            expect(rendered).to.contain("await ethers.getContractFactory('MyToken')")
+            expect(rendered).to.contain('const MyToken = await ethers.getContractFactory')
+            expect(rendered).to.contain('const myToken = await MyToken.deploy')
+            expect(rendered).to.contain("await addressBook.saveContract('MyToken'")
+            expect(rendered).to.contain('MyToken deployed to:')
+            // No leftover placeholder text
+            expect(rendered).to.not.contain('__CONTRACT_NAME__')
+            expect(rendered).to.not.contain('__CAMEL_NAME__')
+            expect(rendered).to.not.contain('__CONSTRUCTOR_ARGS__')
+        })
+
+        it('emits an empty .deploy(...) call when no constructor args are supplied', function () {
+            const rendered = renderDeploymentScript({ customName: 'MyToken' })
+
+            expect(rendered).to.contain('const myToken = await MyToken.deploy()')
+        })
+
+        it('forwards constructor arguments to .deploy(...) in source order', function () {
+            const rendered = renderDeploymentScript({
+                customName: 'MyToken',
+                constructorArgs: ['0xTokenAddress', '1000000']
+            })
+
+            expect(rendered).to.contain('const myToken = await MyToken.deploy(0xTokenAddress, 1000000)')
+        })
+    })
+
+    describe('flag helpers', function () {
+        it('round-trips a contract name with no constructor args', function () {
+            const formatted = formatAddDeploymentScriptFlag('MyToken')
+            expect(formatted).to.equal('MyToken')
+            const parsed = parseAddDeploymentScriptFlag(formatted)
+            expect(parsed).to.deep.equal({ contractName: 'MyToken', constructorArgs: [] })
+        })
+
+        it('round-trips a contract name with constructor args', function () {
+            const formatted = formatAddDeploymentScriptFlag('MyToken', ['0xToken', '42'])
+            expect(formatted).to.equal('MyToken:0xToken:42')
+            const parsed = parseAddDeploymentScriptFlag(formatted)
+            expect(parsed).to.deep.equal({ contractName: 'MyToken', constructorArgs: ['0xToken', '42'] })
+        })
+
+        it('returns undefined for an empty or malformed flag value', function () {
+            expect(parseAddDeploymentScriptFlag(undefined)).to.equal(undefined)
+            expect(parseAddDeploymentScriptFlag('')).to.equal(undefined)
+            expect(parseAddDeploymentScriptFlag(':leadingColon')).to.equal(undefined)
+        })
+    })
+
+    describe('buildDeploymentContract', function () {
+        it('creates scripts/ when it does not exist', function () {
+            expect(fs.existsSync('scripts')).to.equal(false)
+
+            const writtenPath = buildDeploymentContract('MyToken')
+
+            expect(writtenPath).to.equal('scripts/deploy-my-token.ts')
+            expect(fs.existsSync('scripts')).to.equal(true)
+            expect(fs.existsSync('scripts/deploy-my-token.ts')).to.equal(true)
+        })
+
+        it('leaves an existing scripts/ directory and its files untouched', function () {
+            fs.mkdirSync('scripts')
+            const userScript = path.join('scripts', 'my-existing-script.ts')
+            fs.writeFileSync(userScript, '// user script')
+
+            buildDeploymentContract('MyToken')
+
+            expect(fs.readFileSync(userScript, 'utf8')).to.equal('// user script')
+            expect(fs.existsSync('scripts/deploy-my-token.ts')).to.equal(true)
+        })
+
+        it('does not overwrite an existing deployment script', function () {
+            fs.mkdirSync('scripts')
+            const existing = path.join('scripts', 'deploy-my-token.ts')
+            fs.writeFileSync(existing, '// user edits')
+
+            const result = buildDeploymentContract('MyToken')
+
+            expect(result).to.equal(undefined)
+            expect(fs.readFileSync(existing, 'utf8')).to.equal('// user edits')
+        })
+
+        it('writes a CommonJS script for hardhat.config.js projects', function () {
+            fs.rmSync('hardhat.config.ts')
+            fs.writeFileSync('hardhat.config.js', 'module.exports = {}\n')
+
+            const writtenPath = buildDeploymentContract('MyToken')
+
+            expect(writtenPath).to.equal('scripts/deploy-my-token.js')
+            expect(fs.existsSync('scripts/deploy-my-token.ts')).to.equal(false)
+            const generated = fs.readFileSync('scripts/deploy-my-token.js', 'utf8')
+            expect(generated).to.contain("const { addressBook, ethers, network } = require('hardhat')")
+            expect(generated).to.contain("getContractFactory('MyToken')")
+            expect(generated).to.not.match(/@ts-ignore-next-line/)
+            expect(generated).to.contain('.then(() => process.exit(0))')
+        })
+
+        it('forwards constructor arguments to the generated script', function () {
+            buildDeploymentContract('MyToken', { constructorArgs: ['0xToken', '42'] })
+
+            const generated = fs.readFileSync('scripts/deploy-my-token.ts', 'utf8')
+            expect(generated).to.contain('const myToken = await MyToken.deploy(0xToken, 42)')
+            expect(generated).to.contain("addressBook.saveContract('MyToken'")
+        })
+
+        it('uses PascalCase identifiers for multi-word contract names', function () {
+            buildDeploymentContract('MyERC20Token')
+
+            const generated = fs.readFileSync('scripts/deploy-my-erc20-token.ts', 'utf8')
+            expect(generated).to.contain("getContractFactory('MyERC20Token')")
+            expect(generated).to.contain('const MyERC20Token = await ethers.getContractFactory')
+            expect(generated).to.contain('const myERC20Token = await MyERC20Token.deploy')
+        })
+
+        it('is a no-op when no contract name is supplied', function () {
+            const result = buildDeploymentContract('')
+
+            expect(result).to.equal(undefined)
+            expect(fs.existsSync('scripts')).to.equal(false)
+        })
+    })
+})


### PR DESCRIPTION
## Summary

Resolves #166.

Adds a new **Create deployment scripts** menu entry and matching
`--addDeploymentScript <ContractName>[:<arg1>:<arg2>:...]` CLI flag that
scaffold `scripts/deploy-<Name>.{ts,js}` for any contract under
`contracts/`.

The generated script imports `addressBook` from `hardhat`, deploys the
contract (forwarding any constructor arguments to `<Contract>.deploy(...)`),
and writes the deployed address to `contractsAddressDeployed.json` via
`addressBook.saveContract(...)` — ready to run with `npx hardhat run
scripts/deploy-<Name>.ts --network <network>`.

## Behaviour

- Reuses the contracts file listing, so files excluded via the *More
  settings → Exclude contract file* menu stay excluded.
- Creates `scripts/` on demand without touching existing files
  (`recursive: true` keeps unrelated user scripts intact).
- Refuses to overwrite an existing `deploy-<Name>.{ts,js}`.
- Generates CommonJS output for `hardhat.config.js` projects (using the
  same `transformTsToJs` helper as the mock contract creator) and
  TypeScript otherwise.
- Replaces the previously-empty `serveDeploymentContractCreatorSelector`
  stub with a real implementation.

## Out of scope

- This PR deliberately does not auto-deploy the contract after generation.
  The menu still ends after writing the file, and the generated script is
  invoked via `npx hardhat run` as today.
- An optional verify hook (mentioned in the issue's "Proposed scope")
  is left for issue #170, which already covers that flow end-to-end.

## Verification

- `npm run lint` — clean
- `npm test` — 221 tests passing (3 new files / 17 new cases for the
  deployment-script generator)
- `npm run build` — compiles without errors
- `npm run smoke` — passes (plugin loads, `cli` task registers,
  `paths.cli` is injected by the config hook)

## Checklist

- [x] User can generate a deploy script via menu and/or flag
- [x] Generated script follows project conventions and uses
      `addressBook.saveContract(...)`
- [x] Documented in README
- [x] `.changeset/deployment-contract-generator.md` added for the next
      release