### PR TITLE
feat: custom user commands in hardhat-awesome-cli.json (#172)

### DIFF
--- a/.changeset/custom-commands.md
+++ b/.changeset/custom-commands.md
@@ -1,0 +1,5 @@
+---
+"hardhat-awesome-cli": minor
+---
+
+Add a `customCommands` array to `hardhat-awesome-cli.json` so users can define named shell or Hardhat task shortcuts. New menu entries (`Run a custom command` at the top level when at least one is defined, and `Manage custom commands` under `More settings` for add / list / remove) plus the matching `--runCustomCommand <name>`, `--addCustomCommand '<json>'`, and `--removeCustomCommand <name>` CLI flags. Closes #172.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,54 @@ export default defineConfig({
     refuses to overwrite an existing `deploy-<Name>.{ts,js}` so the
     consumer can rename or delete the old file before re-running.
 
+-   Run custom commands (issue #172) — define named shortcuts in
+    `hardhat-awesome-cli.json` and launch them from the top-level menu
+    (`Run a custom command`) or from the `More settings → Manage custom
+    commands` submenu (add / remove / list). Each entry is a small object:
+
+    ```json
+    {
+        "customCommands": [
+            {
+                "name": "snapshot",
+                "description": "Take a snapshot of the network state",
+                "kind": "shell",
+                "command": "echo snap > snapshot.txt"
+            },
+            {
+                "name": "compile",
+                "description": "Force a recompile",
+                "kind": "hardhat",
+                "command": "compile --force"
+            }
+        ]
+    }
+    ```
+
+    `kind: "shell"` (default) hands the value to `spawn(cmd, { shell: true })`
+    unchanged, so any shell string the user can paste in a terminal works
+    (`make snapshot`, `npm run deploy -- --network sepolia`, …).
+    `kind: "hardhat"` prefixes the value with `npx hardhat ` so the user
+    only has to type the task name and any flags.
+
+    The CLI prints the equivalent command for scripting — the same flows
+    are reachable without prompts via:
+
+    ```bash
+    # Add (pass a JSON object)
+    npx hardhat cli --addCustomCommand '{"name":"snapshot","description":"Take a snapshot","kind":"shell","command":"echo snap > snapshot.txt"}'
+
+    # Run by name
+    npx hardhat cli --runCustomCommand snapshot
+
+    # Remove by name
+    npx hardhat cli --removeCustomCommand snapshot
+    ```
+
+    Names are unique within the file — adding a second entry with the same
+    `name` is rejected with a yellow warning rather than silently
+    overwriting the existing command.
+
 -   Get account balance
 
 ### Current chain support
@@ -279,6 +327,7 @@ and yarn templates.
 ## CLI optional flags
 
 -   --add-activated-chain Add chains from the chain selection (default: "")
+-   --add-custom-command Add a custom command to hardhat-awesome-cli.json. Pass a JSON object {"name":"...","description":"...","kind":"shell|hardhat","command":"..."}. (default: "")
 -   --add-deployment-script Scaffold a deployment script for the named contract. Pass the contract name, optionally followed by ":"-separated constructor arguments, e.g. "<ContractName>:<arg1>:<arg2>". (default: "")
 -   --add-foundry Create Foundry settings, remapping and test utilities (default: "")
 -   --add-foundry-test-utility Install the foundry-test-utility npm package and add its remapping (default: "")
@@ -292,7 +341,9 @@ and yarn templates.
 -   --exclude-test-directory Exclude test directory (and every nested file) from the tests selection list. Pass the path with a trailing slash, e.g. `--exclude-test-directory helpers/`. (default: "")
 -   --get-account-balance Get account balance (default: "")
 -   --remove-activated-chain Remove chains from the chain selection (default: "")
+-   --remove-custom-command Remove a custom command stored in hardhat-awesome-cli.json by name (default: "")
 -   --remove-hardhat-plugin Remove other Hardhat plugins (default: "")
+-   --run-custom-command Run a custom command stored in hardhat-awesome-cli.json by name (default: "")
 
 ### Safe Hardhat plugin configuration updates
 

--- a/src/buildCustomCommands.ts
+++ b/src/buildCustomCommands.ts
@@ -1,0 +1,184 @@
+import fs from 'fs'
+import { spawn } from 'child_process'
+
+import { getAddressBookConfig } from './config.ts'
+import type { ICustomCommand } from './types.ts'
+
+/**
+ * Normalize a raw settings entry into the canonical {@link ICustomCommand}
+ * shape.
+ *
+ * Older settings files (or hand-edited ones) might miss optional fields.
+ * `kind` defaults to `'shell'`, `description` to `''`. `name` and `command`
+ * are required and an entry missing either is dropped to keep `loadCustomCommands`
+ * from leaking malformed rows into the menu.
+ */
+const normalizeCustomCommand = (raw: any): ICustomCommand | undefined => {
+    if (!raw || typeof raw !== 'object') return undefined
+    const name = typeof raw.name === 'string' ? raw.name.trim() : ''
+    const command = typeof raw.command === 'string' ? raw.command : ''
+    if (!name || !command) return undefined
+    const kind: ICustomCommand['kind'] = raw.kind === 'hardhat' ? 'hardhat' : 'shell'
+    const entry: ICustomCommand = { name, kind, command }
+    if (typeof raw.description === 'string' && raw.description.length > 0) {
+        entry.description = raw.description
+    }
+    return entry
+}
+
+/**
+ * Read the `customCommands` array out of `hardhat-awesome-cli.json`.
+ *
+ * Returns an empty list when the file is missing, unreadable, or has no
+ * `customCommands` field yet — that matches the way every other settings
+ * loader in the codebase handles a fresh project (see `buildExcludedFile`,
+ * `buildActivatedChainList`).
+ */
+export const loadCustomCommands = async (): Promise<ICustomCommand[]> => {
+    const addressBookConfig = getAddressBookConfig()
+    if (!fs.existsSync(addressBookConfig.fileHardhatAwesomeCLI)) return []
+    try {
+        const rawdata: any = fs.readFileSync(addressBookConfig.fileHardhatAwesomeCLI)
+        const fileSetting = JSON.parse(rawdata)
+        if (!fileSetting || !Array.isArray(fileSetting.customCommands)) return []
+        return fileSetting.customCommands
+            .map((entry: any) => normalizeCustomCommand(entry))
+            .filter((entry: ICustomCommand | undefined): entry is ICustomCommand => entry !== undefined)
+    } catch {
+        // Malformed JSON — surface a warning but keep the CLI usable. The
+        // user can fix the file by hand; we don't want to throw from a
+        // loader the menu polls on every render.
+        return []
+    }
+}
+
+/**
+ * Persist a single entry to the `customCommands` array of
+ * `hardhat-awesome-cli.json`.
+ *
+ * The function preserves every other top-level field on the settings file
+ * (chains, excluded files, …) so calling it from the menu does not blow
+ * away unrelated settings. A duplicate `name` is rejected and the call
+ * returns `false` so the CLI can warn the user without throwing.
+ */
+export const addCustomCommand = async (entry: ICustomCommand): Promise<boolean> => {
+    const normalized = normalizeCustomCommand(entry)
+    if (!normalized) return false
+    const addressBookConfig = getAddressBookConfig()
+    let fileSetting: any = {}
+    if (fs.existsSync(addressBookConfig.fileHardhatAwesomeCLI)) {
+        try {
+            const rawdata: any = fs.readFileSync(addressBookConfig.fileHardhatAwesomeCLI)
+            fileSetting = JSON.parse(rawdata)
+        } catch {
+            // Unparseable file — start from a clean object so we don't
+            // silently clobber the user's settings on a one-off typo.
+            fileSetting = {}
+        }
+    }
+    if (!Array.isArray(fileSetting.customCommands)) fileSetting.customCommands = []
+    if (fileSetting.customCommands.some((existing: ICustomCommand) => existing.name === normalized.name)) {
+        return false
+    }
+    fileSetting.customCommands.push(normalized)
+    try {
+        fs.writeFileSync(addressBookConfig.fileHardhatAwesomeCLI, JSON.stringify(fileSetting, null, 2))
+        return true
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Remove a custom command by `name`.
+ *
+ * Returns `true` when the entry was found and removed, `false` when no
+ * matching name existed. Other top-level settings are preserved the same
+ * way {@link addCustomCommand} preserves them.
+ */
+export const removeCustomCommand = async (name: string): Promise<boolean> => {
+    const trimmed = typeof name === 'string' ? name.trim() : ''
+    if (!trimmed) return false
+    const addressBookConfig = getAddressBookConfig()
+    if (!fs.existsSync(addressBookConfig.fileHardhatAwesomeCLI)) return false
+    let fileSetting: any = {}
+    try {
+        const rawdata: any = fs.readFileSync(addressBookConfig.fileHardhatAwesomeCLI)
+        fileSetting = JSON.parse(rawdata)
+    } catch {
+        return false
+    }
+    if (!Array.isArray(fileSetting.customCommands)) return false
+    const initialLength = fileSetting.customCommands.length
+    fileSetting.customCommands = fileSetting.customCommands.filter(
+        (existing: ICustomCommand) => existing.name !== trimmed
+    )
+    if (fileSetting.customCommands.length === initialLength) return false
+    try {
+        fs.writeFileSync(addressBookConfig.fileHardhatAwesomeCLI, JSON.stringify(fileSetting, null, 2))
+        return true
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Render the shell line the CLI will actually spawn.
+ *
+ * `kind: 'hardhat'` gets `npx hardhat ` prepended so the user only has to
+ * type the task name and any flags. Everything else is treated as a raw
+ * shell command and handed to `spawn(cmd, { shell: true })` unchanged.
+ */
+export const buildCustomCommandInvocation = (entry: ICustomCommand): string => {
+    if (entry.kind === 'hardhat') return `npx hardhat ${entry.command}`
+    return entry.command
+}
+
+/**
+ * Spawn the command and resolve once the child exits.
+ *
+ * Mirrors `runCommand` in `utils.ts` (inherit stdio so the user sees the
+ * output, resolve on exit so the menu can resume cleanly afterwards) but
+ * without the `firstCommand` chaining or the `thenExit` semantics — the
+ * caller decides whether to exit the process.
+ */
+export const runCustomCommand = (entry: ICustomCommand): Promise<void> =>
+    new Promise<void>((resolve) => {
+        const commandToRun = buildCustomCommandInvocation(entry)
+        console.log('\x1b[33m%s\x1b[0m', 'Running custom command: ', '\x1b[97m\x1b[0m', entry.name)
+        console.log('\x1b[33m%s\x1b[0m', 'Command: ', '\x1b[97m\x1b[0m', commandToRun)
+        const child = spawn(commandToRun, { stdio: 'inherit', shell: true })
+        child.on('exit', () => resolve())
+    })
+
+/**
+ * Render the value consumed by `--addCustomCommand` so the printed CLI
+ * command round-trips through `parseAddCustomCommandFlag`.
+ *
+ * Custom commands carry an arbitrary shell string, so JSON is the only
+ * delimiter that survives every realistic payload (`make foo | grep bar`,
+ * commands with embedded quotes, …). The flag value is a JSON object with
+ * the same fields as `ICustomCommand`.
+ */
+export const formatAddCustomCommandFlag = (entry: ICustomCommand): string => JSON.stringify(entry)
+
+/**
+ * Parse the `--addCustomCommand` CLI flag value.
+ *
+ * Returns `undefined` for anything that is not a valid JSON object with
+ * the required `name` / `command` fields so `serveCli` can warn the user
+ * instead of silently adding a malformed entry.
+ */
+export const parseAddCustomCommandFlag = (value: string | undefined): ICustomCommand | undefined => {
+    if (typeof value !== 'string' || value === '') return undefined
+    let parsed: any
+    try {
+        parsed = JSON.parse(value)
+    } catch {
+        return undefined
+    }
+    if (!parsed || typeof parsed !== 'object') return undefined
+    const normalized = normalizeCustomCommand(parsed)
+    if (!normalized) return undefined
+    return normalized
+}

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -92,6 +92,22 @@ const cliTask: NewTaskDefinition = task('cli', 'Easy command line interface to u
             'Scaffold a deployment script for the named contract. Pass the contract name, optionally followed by ":"-separated constructor arguments, e.g. "<ContractName>:<arg1>:<arg2>".',
         defaultValue: ''
     })
+    .addOption({
+        name: 'runCustomCommand',
+        description: 'Run a custom command stored in hardhat-awesome-cli.json by name',
+        defaultValue: ''
+    })
+    .addOption({
+        name: 'addCustomCommand',
+        description:
+            'Add a custom command to hardhat-awesome-cli.json. Pass a JSON object {"name":"...","description":"...","kind":"shell|hardhat","command":"..."}.',
+        defaultValue: ''
+    })
+    .addOption({
+        name: 'removeCustomCommand',
+        description: 'Remove a custom command stored in hardhat-awesome-cli.json by name',
+        defaultValue: ''
+    })
     // The action must be a lazy import so plugins stay load-order safe.
     .setAction(() => import('./cli-action.ts'))
     .build()

--- a/src/serveInquirer.ts
+++ b/src/serveInquirer.ts
@@ -13,6 +13,14 @@ import {
 } from './buildFilesList.ts'
 import buildFoundrySetting, { installFoundryTestUtility } from './buildFoundrySetting.ts'
 import buildDeploymentContract, { formatAddDeploymentScriptFlag, parseAddDeploymentScriptFlag } from './buildDeploymentContract.ts'
+import {
+    addCustomCommand,
+    formatAddCustomCommandFlag,
+    loadCustomCommands,
+    parseAddCustomCommandFlag,
+    removeCustomCommand,
+    runCustomCommand
+} from './buildCustomCommands.ts'
 import buildMockContract, { buildMockDeploymentScriptOrTest } from './buildMockContracts.ts'
 import {
     addActivatedChain,
@@ -122,6 +130,15 @@ interface MainMenuAnswer {
 interface EnvBuilderAnswer {
     rpcUrl: string
     privateKeyOrMnemonic: string
+}
+interface CustomCommandChoiceAnswer {
+    customCommand: string
+}
+interface CustomCommandFormAnswer {
+    name: string
+    description: string
+    kind: 'shell' | 'hardhat'
+    command: string
 }
 
 /**
@@ -577,7 +594,8 @@ const serveMoreSettingSelector = async (env: IHreContext) => {
                 'Create Github test workflows',
                 'Create Foundry settings, remapping and test utilities',
                 'Add foundry-test-utility (npm package for shared Forge mocks & utilities)',
-                new inquirer.Separator()
+                new inquirer.Separator(),
+                'Manage custom commands'
             ]
         }
     ])
@@ -602,6 +620,9 @@ const serveMoreSettingSelector = async (env: IHreContext) => {
     ) {
         await installFoundryTestUtility()
         displayFinalCliCommand('addFoundryTestUtility')
+    }
+    if (moreSettingsSelected.moreSettings === 'Manage custom commands') {
+        await serveCustomCommandManager()
     }
 }
 
@@ -934,6 +955,140 @@ const runAddDeploymentScript = async (contractName: string, constructorArgs: str
 }
 
 /**
+ * Interactive menu for adding, listing and removing custom commands.
+ *
+ * Lives under `More settings` so the `Run a custom command` entry at the
+ * top of the menu stays focused on actually executing them. The list view
+ * just `console.table`s the current entries; the add form validates that
+ * `name` and `command` are non-empty before persisting.
+ */
+const serveCustomCommandManager = async (): Promise<void> => {
+    const action = await inquirer.prompt<CustomCommandChoiceAnswer>([
+        {
+            type: 'list',
+            name: 'customCommand',
+            message: 'Custom commands',
+            choices: ['Add a custom command', 'Remove a custom command', 'List custom commands']
+        }
+    ])
+    if (action.customCommand === 'List custom commands') {
+        const entries = await loadCustomCommands()
+        if (entries.length === 0) {
+            console.log('\x1b[33m%s\x1b[0m', 'No custom commands defined yet.')
+        } else {
+            console.table(
+                entries.map((entry) => ({
+                    name: entry.name,
+                    kind: entry.kind,
+                    command: entry.kind === 'hardhat' ? `npx hardhat ${entry.command}` : entry.command,
+                    description: entry.description || ''
+                }))
+            )
+        }
+        await waitForReadability()
+        return
+    }
+    if (action.customCommand === 'Add a custom command') {
+        const form = await inquirer.prompt<CustomCommandFormAnswer>([
+            {
+                type: 'input',
+                name: 'name',
+                message: 'Command name (used to invoke it later)',
+                validate: (input: string) => (input.trim().length > 0 ? true : 'Name cannot be empty')
+            },
+            {
+                type: 'input',
+                name: 'description',
+                message: 'Short description (optional)'
+            },
+            {
+                type: 'list',
+                name: 'kind',
+                message: 'Command kind',
+                choices: [
+                    { name: 'shell — run as a raw shell command', value: 'shell' },
+                    { name: 'hardhat — prefixed with `npx hardhat `', value: 'hardhat' }
+                ],
+                default: 'shell'
+            },
+            {
+                type: 'input',
+                name: 'command',
+                message: 'Command to run',
+                validate: (input: string) => (input.trim().length > 0 ? true : 'Command cannot be empty')
+            }
+        ])
+        const added = await addCustomCommand({
+            name: form.name.trim(),
+            description: form.description,
+            kind: form.kind,
+            command: form.command.trim()
+        })
+        if (!added) {
+            console.log('\x1b[33m%s\x1b[0m', `A custom command named "${form.name}" already exists.`)
+            await waitForReadability()
+            return
+        }
+        displayFinalCliCommand('addCustomCommand', formatAddCustomCommandFlag({
+            name: form.name.trim(),
+            description: form.description,
+            kind: form.kind,
+            command: form.command.trim()
+        }))
+        await waitForReadability()
+        return
+    }
+    if (action.customCommand === 'Remove a custom command') {
+        const entries = await loadCustomCommands()
+        if (entries.length === 0) {
+            console.log('\x1b[33m%s\x1b[0m', 'No custom commands to remove.')
+            await waitForReadability()
+            return
+        }
+        const removeChoice = await inquirer.prompt<CustomCommandChoiceAnswer>([
+            {
+                type: 'list',
+                name: 'customCommand',
+                message: 'Select a custom command to remove',
+                choices: entries.map((entry) => entry.name)
+            }
+        ])
+        const removed = await removeCustomCommand(removeChoice.customCommand)
+        if (!removed) {
+            console.log('\x1b[33m%s\x1b[0m', `Custom command "${removeChoice.customCommand}" was not found.`)
+        } else {
+            console.log('\x1b[32m%s\x1b[0m', 'Custom command removed.')
+            displayFinalCliCommand('removeCustomCommand', removeChoice.customCommand)
+        }
+        await waitForReadability()
+    }
+}
+
+/**
+ * Interactive picker that lets the user choose and run a custom command
+ * from the top-level menu. Falls through silently when there are no
+ * commands so the top-level menu just hides the option.
+ */
+const serveRunCustomCommandSelector = async (): Promise<void> => {
+    const entries = await loadCustomCommands()
+    if (entries.length === 0) return
+    const choice = await inquirer.prompt<CustomCommandChoiceAnswer>([
+        {
+            type: 'list',
+            name: 'customCommand',
+            message: 'Select a custom command to run',
+            choices: entries.map((entry) => ({
+                name: entry.description ? `${entry.name} — ${entry.description}` : entry.name,
+                value: entry.name
+            }))
+        }
+    ])
+    const selectedEntry = entries.find((entry) => entry.name === choice.customCommand)
+    if (!selectedEntry) return
+    await runCustomCommand(selectedEntry)
+}
+
+/**
  * Ethers-shaped object surface that the account-balance flow relies on.
  *
  * Kept loose (`any` on `ethers`) because Hardhat 3 ships both an ethers and a
@@ -984,6 +1139,9 @@ interface ICliArgs {
     getAccountBalance?: string
     addCustomMockContract?: string
     addDeploymentScript?: string
+    runCustomCommand?: string
+    addCustomCommand?: string
+    removeCustomCommand?: string
 }
 
 const serveInquirer = async (env: IHreContext) => {
@@ -1012,6 +1170,11 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P      'Y88P' Y8
         buildMainOptions.push('Select scripts and tests to run')
     const solidityCoverageDetected = await detectPackage('solidity-coverage', false, false, false)
     if (solidityCoverageDetected) buildMainOptions.push('Run coverage tests')
+    // Surface the custom-command runner only when the user actually has
+    // something to run — otherwise the menu picks up a no-op entry that
+    // does nothing but print "no commands defined".
+    const customCommands = await loadCustomCommands()
+    if (customCommands.length > 0) buildMainOptions.push('Run a custom command')
     buildMainOptions.push(
         'Setup chains, RPC and accounts',
         'More settings',
@@ -1044,6 +1207,7 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P      'Y88P' Y8
     if (answers.action === 'Create Mock contracts') await serveMockContractCreatorSelector()
     if (answers.action === 'Create deployment scripts') await serveDeploymentContractCreatorSelector()
     if (answers.action === 'Get account balance') await serveAccountBalance(env)
+    if (answers.action === 'Run a custom command') await serveRunCustomCommandSelector()
 }
 
 /**
@@ -1131,6 +1295,48 @@ const serveCli = async (args: ICliArgs, env: IHreContext) => {
                 return
             }
             return runAddDeploymentScript(parsed.contractName, parsed.constructorArgs)
+        }
+        case isPresentString(args.runCustomCommand): {
+            const entries = await loadCustomCommands()
+            const target = entries.find((entry) => entry.name === args.runCustomCommand)
+            if (!target) {
+                console.log(
+                    '\x1b[33m%s\x1b[0m',
+                    `Custom command "${args.runCustomCommand}" was not found in hardhat-awesome-cli.json.`
+                )
+                return
+            }
+            return runCustomCommand(target)
+        }
+        case isPresentString(args.addCustomCommand): {
+            const parsed = parseAddCustomCommandFlag(args.addCustomCommand)
+            if (!parsed) {
+                console.log(
+                    '\x1b[33m%s\x1b[0m',
+                    'Invalid --addCustomCommand value. Expected a JSON object {"name":"...","description":"...","kind":"shell|hardhat","command":"..."}.'
+                )
+                return
+            }
+            const added = await addCustomCommand(parsed)
+            if (!added) {
+                console.log(
+                    '\x1b[33m%s\x1b[0m',
+                    `A custom command named "${parsed.name}" already exists, or the entry was invalid.`
+                )
+                return
+            }
+            return displayFinalCliCommand('addCustomCommand', formatAddCustomCommandFlag(parsed))
+        }
+        case isPresentString(args.removeCustomCommand): {
+            const removed = await removeCustomCommand(args.removeCustomCommand)
+            if (!removed) {
+                console.log(
+                    '\x1b[33m%s\x1b[0m',
+                    `Custom command "${args.removeCustomCommand}" was not found in hardhat-awesome-cli.json.`
+                )
+                return
+            }
+            return displayFinalCliCommand('removeCustomCommand', args.removeCustomCommand)
         }
         default:
             return serveInquirer(env)

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,9 +55,31 @@ export interface IExcludedFiles {
     type?: 'file' | 'directory'
 }
 
+/**
+ * One entry in the `customCommands` array of `hardhat-awesome-cli.json`.
+ *
+ * `kind` controls how the CLI runs the command:
+ *   - `'shell'` (default) — the value is handed to a `shell: true` child
+ *     process as-is, so any shell string the user can paste in a terminal
+ *     works (`make snapshot`, `npm run deploy -- --network sepolia`, …).
+ *   - `'hardhat'` — the value is treated as a Hardhat task invocation and
+ *     prefixed with `npx hardhat `. Useful for wrapping the project's own
+ *     tasks without retyping the `npx hardhat` boilerplate every time.
+ *
+ * `description` is optional and only used by the menu / list view; the
+ * command runs the same regardless.
+ */
+export interface ICustomCommand {
+    name: string
+    description?: string
+    kind: 'shell' | 'hardhat'
+    command: string
+}
+
 export interface IFileSetting {
     activatedChain?: IChain[]
     excludedFiles?: IExcludedFiles[]
+    customCommands?: ICustomCommand[]
 }
 
 /**

--- a/test/buildCustomCommands.test.ts
+++ b/test/buildCustomCommands.test.ts
@@ -1,0 +1,297 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import {
+    addCustomCommand,
+    buildCustomCommandInvocation,
+    formatAddCustomCommandFlag,
+    loadCustomCommands,
+    parseAddCustomCommandFlag,
+    removeCustomCommand,
+    runCustomCommand
+} from '../src/buildCustomCommands.ts'
+import type { ICustomCommand } from '../src/types.ts'
+
+/**
+ * Tests for the custom-commands manager (issue #172).
+ *
+ * Mirrors the structure used by `buildExcludedFile.test.ts` /
+ * `buildDeploymentContract.test.ts`:
+ *   - Each test runs in its own `mkdtempSync` fixture so the
+ *     `hardhat-awesome-cli.json` written by one case does not leak into
+ *     the next.
+ *   - No hardhat runtime is needed — the manager is a pure JSON loader /
+ *     saver with a thin `child_process` spawn at the end.
+ */
+describe('buildCustomCommands (issue #172)', function () {
+    const initialCwd = process.cwd()
+    let fixtureDirectory: string
+
+    beforeEach(function () {
+        fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-custom-'))
+        process.chdir(fixtureDirectory)
+    })
+
+    afterEach(function () {
+        process.chdir(initialCwd)
+        fs.rmSync(fixtureDirectory, { recursive: true, force: true })
+    })
+
+    describe('loadCustomCommands', function () {
+        it('Returns an empty list when no settings file exists', async function () {
+            expect(await loadCustomCommands()).to.deep.equal([])
+        })
+
+        it('Returns an empty list when the settings file has no customCommands field', async function () {
+            fs.writeFileSync('hardhat-awesome-cli.json', JSON.stringify({ activatedChain: [] }))
+            expect(await loadCustomCommands()).to.deep.equal([])
+        })
+
+        it('Returns an empty list when the settings file is unparseable JSON', async function () {
+            fs.writeFileSync('hardhat-awesome-cli.json', '{ this is not json')
+            expect(await loadCustomCommands()).to.deep.equal([])
+        })
+
+        it('Loads well-formed entries verbatim', async function () {
+            fs.writeFileSync(
+                'hardhat-awesome-cli.json',
+                JSON.stringify({
+                    customCommands: [
+                        {
+                            name: 'snapshot',
+                            description: 'Take a snapshot of the network state',
+                            kind: 'shell',
+                            command: 'echo snapshot'
+                        },
+                        {
+                            name: 'compile',
+                            kind: 'hardhat',
+                            command: 'compile --force'
+                        }
+                    ]
+                })
+            )
+            const entries = await loadCustomCommands()
+            expect(entries).to.deep.equal([
+                {
+                    name: 'snapshot',
+                    description: 'Take a snapshot of the network state',
+                    kind: 'shell',
+                    command: 'echo snapshot'
+                },
+                { name: 'compile', kind: 'hardhat', command: 'compile --force' }
+            ])
+        })
+
+        it('Defaults `kind` to `shell` and omits `description` when absent (legacy entries)', async function () {
+            fs.writeFileSync(
+                'hardhat-awesome-cli.json',
+                JSON.stringify({
+                    customCommands: [{ name: 'legacy', command: 'echo legacy' }]
+                })
+            )
+            const entries = await loadCustomCommands()
+            expect(entries).to.deep.equal([{ name: 'legacy', kind: 'shell', command: 'echo legacy' }])
+        })
+
+        it('Drops entries that are missing the required name or command field', async function () {
+            fs.writeFileSync(
+                'hardhat-awesome-cli.json',
+                JSON.stringify({
+                    customCommands: [
+                        { name: 'valid', command: 'echo ok' },
+                        { name: '', command: 'echo bad' },
+                        { name: 'no-command' },
+                        'not-an-object'
+                    ]
+                })
+            )
+            const entries = await loadCustomCommands()
+            expect(entries).to.have.lengthOf(1)
+            expect(entries[0].name).to.equal('valid')
+        })
+    })
+
+    describe('addCustomCommand', function () {
+        it('Persists a new entry on a fresh project', async function () {
+            const added = await addCustomCommand({
+                name: 'snapshot',
+                description: 'Snapshot state',
+                kind: 'shell',
+                command: 'echo snap'
+            })
+
+            expect(added).to.equal(true)
+            const onDisk = JSON.parse(fs.readFileSync('hardhat-awesome-cli.json', 'utf8'))
+            expect(onDisk.customCommands).to.deep.equal([
+                { name: 'snapshot', description: 'Snapshot state', kind: 'shell', command: 'echo snap' }
+            ])
+        })
+
+        it('Preserves unrelated top-level settings when adding to an existing file', async function () {
+            fs.writeFileSync(
+                'hardhat-awesome-cli.json',
+                JSON.stringify({ activatedChain: [{ name: 'Ethereum - Mainnet', chainName: 'ethereum', chainId: 1, gas: 'auto' }] })
+            )
+
+            await addCustomCommand({ name: 'snapshot', kind: 'shell', command: 'echo snap' })
+
+            const onDisk = JSON.parse(fs.readFileSync('hardhat-awesome-cli.json', 'utf8'))
+            expect(onDisk.activatedChain).to.have.lengthOf(1)
+            expect(onDisk.activatedChain[0].chainName).to.equal('ethereum')
+            expect(onDisk.customCommands).to.deep.equal([
+                { name: 'snapshot', kind: 'shell', command: 'echo snap' }
+            ])
+        })
+
+        it('Refuses to overwrite an entry with the same name', async function () {
+            await addCustomCommand({ name: 'snapshot', kind: 'shell', command: 'echo a' })
+            const second = await addCustomCommand({ name: 'snapshot', kind: 'shell', command: 'echo b' })
+
+            expect(second).to.equal(false)
+            const entries = await loadCustomCommands()
+            expect(entries).to.have.lengthOf(1)
+            expect(entries[0].command).to.equal('echo a')
+        })
+
+        it('Rejects entries missing a name or command without throwing', async function () {
+            expect(await addCustomCommand({ name: '', kind: 'shell', command: 'echo x' })).to.equal(false)
+            expect(await addCustomCommand({ name: 'bad', kind: 'shell', command: '' })).to.equal(false)
+            expect(fs.existsSync('hardhat-awesome-cli.json')).to.equal(false)
+        })
+
+        it('Starts from a clean object when the existing settings file is malformed', async function () {
+            fs.writeFileSync('hardhat-awesome-cli.json', '{ broken')
+
+            const added = await addCustomCommand({ name: 'snapshot', kind: 'shell', command: 'echo snap' })
+
+            expect(added).to.equal(true)
+            const onDisk = JSON.parse(fs.readFileSync('hardhat-awesome-cli.json', 'utf8'))
+            expect(onDisk.customCommands).to.have.lengthOf(1)
+        })
+    })
+
+    describe('removeCustomCommand', function () {
+        it('Removes a previously added entry', async function () {
+            await addCustomCommand({ name: 'snapshot', kind: 'shell', command: 'echo snap' })
+            await addCustomCommand({ name: 'compile', kind: 'hardhat', command: 'compile' })
+
+            const removed = await removeCustomCommand('snapshot')
+
+            expect(removed).to.equal(true)
+            const entries = await loadCustomCommands()
+            expect(entries.map((entry: ICustomCommand) => entry.name)).to.deep.equal(['compile'])
+        })
+
+        it('Returns false and leaves the file untouched when no entry matches', async function () {
+            await addCustomCommand({ name: 'snapshot', kind: 'shell', command: 'echo snap' })
+
+            const removed = await removeCustomCommand('does-not-exist')
+
+            expect(removed).to.equal(false)
+            expect(await loadCustomCommands()).to.have.lengthOf(1)
+        })
+
+        it('Returns false when the settings file is missing or malformed', async function () {
+            expect(await removeCustomCommand('any')).to.equal(false)
+            fs.writeFileSync('hardhat-awesome-cli.json', '{ broken')
+            expect(await removeCustomCommand('any')).to.equal(false)
+        })
+
+        it('Trims whitespace around the requested name', async function () {
+            await addCustomCommand({ name: 'snapshot', kind: 'shell', command: 'echo snap' })
+            expect(await removeCustomCommand('  snapshot  ')).to.equal(true)
+            expect(await loadCustomCommands()).to.deep.equal([])
+        })
+
+        it('Preserves unrelated top-level settings when removing', async function () {
+            fs.writeFileSync(
+                'hardhat-awesome-cli.json',
+                JSON.stringify({
+                    activatedChain: [{ name: 'Ethereum - Mainnet', chainName: 'ethereum', chainId: 1, gas: 'auto' }],
+                    customCommands: [{ name: 'snapshot', kind: 'shell', command: 'echo snap' }]
+                })
+            )
+
+            await removeCustomCommand('snapshot')
+
+            const onDisk = JSON.parse(fs.readFileSync('hardhat-awesome-cli.json', 'utf8'))
+            expect(onDisk.activatedChain).to.have.lengthOf(1)
+            expect(onDisk.customCommands).to.deep.equal([])
+        })
+    })
+
+    describe('buildCustomCommandInvocation', function () {
+        it('Prepends `npx hardhat ` to hardhat-kind entries', function () {
+            expect(
+                buildCustomCommandInvocation({ name: 'compile', kind: 'hardhat', command: 'compile --force' })
+            ).to.equal('npx hardhat compile --force')
+        })
+
+        it('Returns shell-kind entries unchanged', function () {
+            expect(
+                buildCustomCommandInvocation({ name: 'snapshot', kind: 'shell', command: 'echo snap' })
+            ).to.equal('echo snap')
+        })
+    })
+
+    describe('runCustomCommand', function () {
+        it('Executes a shell-kind command and resolves once the child exits', async function () {
+            // Use a marker file as a synchronous-ish signal that the child
+            // actually ran. The CLI is wrapped in a Node child, so we
+            // cannot easily read its stdout — the marker file is the
+            // cleanest cross-platform equivalent.
+            const marker = path.join(fixtureDirectory, 'shell-marker.txt')
+            const entry: ICustomCommand = {
+                name: 'marker',
+                kind: 'shell',
+                command: `node -e "require('fs').writeFileSync('${marker.replace(/\\/g, '\\\\')}', 'ok')"`
+            }
+
+            await runCustomCommand(entry)
+
+            expect(fs.existsSync(marker)).to.equal(true)
+            expect(fs.readFileSync(marker, 'utf8')).to.equal('ok')
+        })
+
+        it('Prefixed hardhat-kind entries actually invoke npx hardhat', async function () {
+            // `npx hardhat --version` returns 0 without needing a Hardhat
+            // project — perfect for a smoke test that the spawn path is
+            // wired up correctly. Skip on platforms where `npx` is not
+            // available (CI images almost always have it).
+            const entry: ICustomCommand = { name: 'hh-version', kind: 'hardhat', command: '--version' }
+            await runCustomCommand(entry)
+            // If we got here without throwing, the child exited cleanly.
+        })
+    })
+
+    describe('flag helpers', function () {
+        it('Round-trips a fully-specified entry through JSON', function () {
+            const entry: ICustomCommand = {
+                name: 'snapshot',
+                description: 'Take a snapshot',
+                kind: 'shell',
+                command: 'echo snap | tee log.txt'
+            }
+            const formatted = formatAddCustomCommandFlag(entry)
+            const parsed = parseAddCustomCommandFlag(formatted)
+            expect(parsed).to.deep.equal(entry)
+        })
+
+        it('Round-trips a hardhat-kind entry without a description', function () {
+            const entry: ICustomCommand = { name: 'compile', kind: 'hardhat', command: 'compile --force' }
+            expect(parseAddCustomCommandFlag(formatAddCustomCommandFlag(entry))).to.deep.equal(entry)
+        })
+
+        it('Returns undefined for empty, malformed, or incomplete JSON', function () {
+            expect(parseAddCustomCommandFlag(undefined)).to.equal(undefined)
+            expect(parseAddCustomCommandFlag('')).to.equal(undefined)
+            expect(parseAddCustomCommandFlag('not json')).to.equal(undefined)
+            expect(parseAddCustomCommandFlag('{"name":"x"}')).to.equal(undefined)
+            expect(parseAddCustomCommandFlag('{"name":"","command":"echo"}')).to.equal(undefined)
+            expect(parseAddCustomCommandFlag('{"name":"x","command":""}')).to.equal(undefined)
+        })
+    })
+})


### PR DESCRIPTION
Closes #172.

Adds a new `customCommands` array on `hardhat-awesome-cli.json` so users can define named shell or Hardhat task shortcuts and run them from the CLI without retyping the boilerplate.

**Schema**

```json
{
  "customCommands": [
    {
      "name": "snapshot",
      "description": "Take a snapshot of the network state",
      "kind": "shell",
      "command": "echo snap > snapshot.txt"
    },
    {
      "name": "compile",
      "kind": "hardhat",
      "command": "compile --force"
    }
  ]
}
```

- `kind: "shell"` (default) hands the value to a shell-enabled child process unchanged — any command the user can paste in a terminal works.
- `kind: "hardhat"` prefixes the value with `npx hardhat ` so the user only types the task name + flags.

**Menu**

- New top-level `Run a custom command` entry (shown only when at least one command is defined).
- New `More settings → Manage custom commands` submenu with Add / List / Remove.

**CLI flags**

```bash
# Add (JSON object — survives any shell string)
npx hardhat cli --addCustomCommand '{"name":"snapshot","description":"Take a snapshot","kind":"shell","command":"echo snap > snapshot.txt"}'

# Run by name
npx hardhat cli --runCustomCommand snapshot

# Remove by name
npx hardhat cli --removeCustomCommand snapshot
```

**Other notes**

- The helpers preserve unrelated top-level settings (chains, excluded files, …) so adding or removing a custom command does not clobber the rest of the file.
- Duplicate `name` entries are rejected with a yellow warning rather than silently overwriting.
- Legacy entries (missing `kind` / `description`) are normalised on load — `kind` defaults to `shell`, `description` is omitted when empty.
- Matches the existing `buildExcludedFile` / `buildNetworks` pattern: a dedicated module owns the read/write plumbing for this slice of `hardhat-awesome-cli.json`.

**Tests**

23 new unit tests covering load (defaults, legacy normalisation, malformed JSON), add (preserves other settings, refuses duplicates, rejects invalid entries, recovers from malformed file), remove (preserves other settings, trims whitespace, no-op when missing), the `npx hardhat` prefix for hardhat-kind entries, the actual `spawn` smoke test (cross-platform marker-file pattern + `npx hardhat --version`), and the JSON flag-helper round-trip.