### PR TITLE
feat(verify-contract): add contract verification menu and CLI flag (issue #170)

### DIFF
--- a/.changeset/verify-contract.md
+++ b/.changeset/verify-contract.md
@@ -1,0 +1,5 @@
+---
+"hardhat-awesome-cli": minor
+---
+
+Add a `Verify a contract` menu entry and matching `--verifyContract <network>:<contractNameOrAddress>[:<arg1>:<arg2>:...]` CLI flag. The interactive flow walks through network selection, contract identification (from the address book or a manually-pasted 0x-prefixed address), and optional constructor arguments before running `npx hardhat verify <address> --network <network> [args...]`. When no `@nomicfoundation/hardhat-verify` (or `hardhat-verify`) dependency is detected in `package.json`, the CLI prints a clear install hint instead of failing at the explorer API. Closes #170.

--- a/README.md
+++ b/README.md
@@ -279,6 +279,31 @@ export default defineConfig({
     `name` is rejected with a yellow warning rather than silently
     overwriting the existing command.
 
+-   Verify a contract
+
+    Verifies a deployed contract on a block explorer. The interactive menu
+    walks through network selection, contract identification (from the
+    address book or a manually-pasted 0x-prefixed address), and optional
+    constructor arguments. The same flow is reachable from the CLI with a
+    single flag:
+
+    ```bash
+    # Resolve from the address book by name
+    npx hardhat cli --verifyContract ethereumSepolia:MockERC20
+
+    # Pass a 0x-prefixed address directly
+    npx hardhat cli --verifyContract ethereumSepolia:0x1234567890abcdef1234567890abcdef12345678
+
+    # Pass constructor arguments when the plugin needs them
+    npx hardhat cli --verifyContract ethereumSepolia:MockERC20:0xToken:42
+    ```
+
+    The flag value is `<network>:<contractNameOrAddress>[:<arg1>:<arg2>:...]`,
+    which mirrors the format printed by the menu and round-trips through
+    `parseVerifyContractFlag`. When no `@nomicfoundation/hardhat-verify`
+    (or `hardhat-verify`) dependency is detected in `package.json`, the CLI
+    prints a clear install hint instead of silently failing.
+
 -   Get account balance
 
 ### Current chain support
@@ -344,6 +369,7 @@ and yarn templates.
 -   --remove-custom-command Remove a custom command stored in hardhat-awesome-cli.json by name (default: "")
 -   --remove-hardhat-plugin Remove other Hardhat plugins (default: "")
 -   --run-custom-command Run a custom command stored in hardhat-awesome-cli.json by name (default: "")
+-   --verify-contract Verify a deployed contract on a block explorer. Pass "<network>:<contractNameOrAddress>[:<arg1>:<arg2>:...]" — the contract name is resolved from the address book, or pass a 0x-prefixed address directly. (default: "")
 
 ### Safe Hardhat plugin configuration updates
 

--- a/src/buildVerifyContract.ts
+++ b/src/buildVerifyContract.ts
@@ -1,0 +1,246 @@
+import fs from 'fs'
+
+import { getAddressBookConfig } from './config.ts'
+import { runCommand } from './utils.ts'
+import type { IChain } from './types.ts'
+
+/**
+ * Inputs accepted by {@link runVerifyContract}.
+ *
+ * `contractNameOrAddress` is opaque: it can be either an Ethereum address
+ * (`0x…` — validated with {@link isEthereumAddress}) or a contract name from
+ * the address book (resolved by {@link resolveContractAddress}). All
+ * validation lives in the helpers so the menu and the CLI flag dispatcher
+ * share the same code path.
+ *
+ * `constructorArgs` is forwarded to `npx hardhat verify <address> --network
+ * <network> <arg1> <arg2> …`. Both `@nomicfoundation/hardhat-verify` and
+ * the Hardhat 3 built-in verify task accept positional arguments after the
+ * address, so the same shell invocation works for both.
+ */
+export interface IVerifyContractOptions {
+    network: string
+    contractNameOrAddress: string
+    constructorArgs?: string[]
+}
+
+/**
+ * Minimal subset of the address book entry we need to resolve a contract.
+ * Mirrors the field set on `AwesomeAddressBook` / `IContractAddressDeployed`
+ * but kept local so the verify module does not depend on the address-book
+ * class.
+ */
+interface IDeployedContractEntry {
+    name: string
+    address: string
+    network: string
+}
+
+/**
+ * Load the address book — the JSON file the project writes from
+ * `addressBook.saveContract` after every deployment.
+ *
+ * Returns an empty list when the file is missing, unreadable, or unparseable
+ * so the caller can fall through to the manual-address branch without
+ * throwing from a loader. The same defensive pattern is used in
+ * `buildCustomCommands` / `buildExcludedFile`.
+ */
+export const loadDeployedContracts = (userConfig?: { addressBook?: any }): IDeployedContractEntry[] => {
+    const addressBookConfig = getAddressBookConfig(userConfig)
+    const filePath = addressBookConfig.savePath + addressBookConfig.fileContractsAddressDeployed
+    if (!fs.existsSync(filePath)) return []
+    try {
+        const rawdata: any = fs.readFileSync(filePath)
+        const parsed = JSON.parse(rawdata)
+        if (!Array.isArray(parsed)) return []
+        return parsed
+            .filter((entry: any) => entry && typeof entry.name === 'string' && typeof entry.address === 'string')
+            .map((entry: any) => ({
+                name: entry.name,
+                address: entry.address,
+                network: entry.network
+            }))
+    } catch {
+        return []
+    }
+}
+
+/**
+ * Resolve an address-book entry name to its on-chain address for the given
+ * network.
+ *
+ * Returns `undefined` when no entry matches (the caller prints a friendly
+ * warning and falls back to the manual-address branch). The address book
+ * stores one entry per `(name, network)` pair, so a single match is the
+ * expected happy path; multiple matches are reduced to the first one to
+ * match the historical `retrieveContract` behaviour.
+ */
+export const resolveContractAddress = (
+    contractName: string,
+    network: string,
+    userConfig?: { addressBook?: any }
+): string | undefined => {
+    const entries = loadDeployedContracts(userConfig).filter(
+        (entry: IDeployedContractEntry) => entry.name === contractName && entry.network === network
+    )
+    if (entries.length === 0) return undefined
+    return entries[0].address
+}
+
+/**
+ * Cheap Ethereum-address validation. We only need to catch the obvious
+ * mistakes (typos, paste garbage) here — Hardhat itself will reject the
+ * command at runtime if the address is on the wrong chain or has no code.
+ *
+ * Accepts both lower- and upper-case hex, an optional `0x` prefix, and the
+ * canonical 40-hex-character length.
+ */
+export const isEthereumAddress = (value: string): boolean => {
+    if (typeof value !== 'string') return false
+    const trimmed = value.trim()
+    if (trimmed.length !== 40 && trimmed.length !== 42) return false
+    const hex = trimmed.startsWith('0x') || trimmed.startsWith('0X') ? trimmed.slice(2) : trimmed
+    return /^[0-9a-fA-F]{40}$/.test(hex)
+}
+
+/**
+ * Build the `npx hardhat verify` command for the given contract.
+ *
+ * The `--network <network>` flag is appended first so subsequent positional
+ * arguments land where both `@nomicfoundation/hardhat-verify` and the
+ * Hardhat 3 built-in verify task expect them. Constructor arguments are
+ * shell-quoted with single quotes — they typically contain commas and full
+ * stops (`0x...`, `42`) but never apostrophes per the Hardhat 2-era
+ * conventions this code follows.
+ */
+export const buildVerifyCommand = (network: string, address: string, constructorArgs: string[] = []): string => {
+    const quotedArgs = constructorArgs.map((arg: string) => `'${arg.replace(/'/g, "'\\''")}'`)
+    return [`npx hardhat verify`, address, '--network', network, ...quotedArgs].join(' ')
+}
+
+/**
+ * Resolve the address-book reference, run the build, and then invoke the
+ * `npx hardhat verify` command. Surfaces a clear error when the verify
+ * plugin is missing so the user knows what to install next.
+ *
+ * Returns `true` when the command was invoked successfully, `false` when
+ * validation failed (so the CLI flag dispatcher can warn without throwing).
+ */
+export const runVerifyContract = async (options: IVerifyContractOptions): Promise<boolean> => {
+    const network = options.network?.trim()
+    const contractNameOrAddress = options.contractNameOrAddress?.trim()
+    if (!network || !contractNameOrAddress) {
+        console.log(
+            '\x1b[33m%s\x1b[0m',
+            'Both --network and a contract name or address are required to verify a contract.'
+        )
+        return false
+    }
+
+    let address = contractNameOrAddress
+    if (!isEthereumAddress(contractNameOrAddress)) {
+        const resolved = resolveContractAddress(contractNameOrAddress, network)
+        if (!resolved) {
+            console.log(
+                '\x1b[33m%s\x1b[0m',
+                `Contract "${contractNameOrAddress}" was not found in the address book for network "${network}". ` +
+                    'Pass a 0x… address directly to verify without an address-book entry.'
+            )
+            return false
+        }
+        address = resolved
+    }
+
+    const command = buildVerifyCommand(network, address, options.constructorArgs ?? [])
+    if (!isVerifyPluginInstalled()) {
+        console.log(
+            '\x1b[33m%s\x1b[0m',
+            'No contract-verification plugin was detected. Install @nomicfoundation/hardhat-verify ' +
+                'and add it to your hardhat.config.ts plugins list before running this command.'
+        )
+        console.log('\x1b[33m%s\x1b[0m', 'Equivalent CLI command: ', '\x1b[97m\x1b[0m', command)
+        return true
+    }
+    await runCommand(command, '', '', true)
+    return true
+}
+
+/**
+ * Heuristic check for the verify plugin. We look at the project's
+ * `package.json` (the same source the Hardhat plugin loader uses) so a
+ * user running `npx hardhat verify` outside of this CLI gets the same
+ * "install the plugin" message. We do not parse the resolved config here
+ * because that requires a live Hardhat runtime environment.
+ */
+export const isVerifyPluginInstalled = (): boolean => {
+    if (!fs.existsSync('package.json')) return false
+    try {
+        const rawdata: any = fs.readFileSync('package.json')
+        const pkg = JSON.parse(rawdata)
+        const deps = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) }
+        return Boolean(deps['@nomicfoundation/hardhat-verify'] || deps['hardhat-verify'])
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Render the value consumed by `--verifyContract` so the printed CLI
+ * command round-trips through {@link parseVerifyContractFlag}.
+ *
+ * Shape: `<network>:<contractNameOrAddress>[:<arg1>:<arg2>:...]`. The
+ * network is the first segment so the CLI dispatcher can pull it out
+ * without traversing the rest of the value (matches the
+ * `--addDeploymentScript` pattern).
+ */
+export const formatVerifyContractFlag = (
+    network: string,
+    contractNameOrAddress: string,
+    constructorArgs: string[] = []
+): string => {
+    const parts = [network, contractNameOrAddress, ...constructorArgs]
+    return parts.join(':')
+}
+
+/**
+ * Parse the `--verifyContract` CLI flag value.
+ *
+ * Returns `undefined` when the value is missing or empty so `serveCli`
+ * can fall through to the next flag instead of invoking the verify flow
+ * with garbage. The first segment is the network, the second is the
+ * contract name or address, and any remaining segments are constructor
+ * arguments — matches the format rendered by {@link formatVerifyContractFlag}.
+ */
+export const parseVerifyContractFlag = (
+    value: string | undefined
+): { network: string; contractNameOrAddress: string; constructorArgs: string[] } | undefined => {
+    if (typeof value !== 'string' || value.trim() === '') return undefined
+    const parts = value.split(':')
+    if (parts.length < 2) return undefined
+    const [network, contractNameOrAddress, ...constructorArgs] = parts
+    if (!network || !contractNameOrAddress) return undefined
+    return { network, contractNameOrAddress, constructorArgs }
+}
+
+/**
+ * Helper used by the menu to list the address-book entries that match a
+ * given network. Returns `[]` when the address book is empty so the menu
+ * can short-circuit to the manual-address branch.
+ */
+export const listDeployedContractsForNetwork = (
+    network: string,
+    userConfig?: { addressBook?: any }
+): IDeployedContractEntry[] => {
+    return loadDeployedContracts(userConfig).filter((entry: IDeployedContractEntry) => entry.network === network)
+}
+
+/**
+ * Compute the chain short-name from a human-readable chain entry, matching
+ * the selector used by `serveNetworkSelector`. Centralised here so the
+ * flag dispatcher and the menu agree on the network value to feed into
+ * `npx hardhat verify --network <shortName>`.
+ */
+export const resolveChainShortName = (chain: IChain, activatedChainList: IChain[]): string => {
+    const match = activatedChainList.find((entry: IChain) => entry.name === chain.name)
+    return match?.chainName ?? chain.chainName
+}

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -108,6 +108,12 @@ const cliTask: NewTaskDefinition = task('cli', 'Easy command line interface to u
         description: 'Remove a custom command stored in hardhat-awesome-cli.json by name',
         defaultValue: ''
     })
+    .addOption({
+        name: 'verifyContract',
+        description:
+            'Verify a deployed contract on a block explorer. Pass "<network>:<contractNameOrAddress>[:<arg1>:<arg2>:...]" — the contract name is resolved from the address book, or pass a 0x-prefixed address directly.',
+        defaultValue: ''
+    })
     // The action must be a lazy import so plugins stay load-order safe.
     .setAction(() => import('./cli-action.ts'))
     .build()

--- a/src/serveInquirer.ts
+++ b/src/serveInquirer.ts
@@ -29,6 +29,14 @@ import {
     buildNetworkSelectorChoices,
     removeActivatedChain
 } from './buildNetworks.ts'
+import {
+    formatVerifyContractFlag,
+    isEthereumAddress,
+    listDeployedContractsForNetwork,
+    parseVerifyContractFlag,
+    resolveChainShortName,
+    runVerifyContract
+} from './buildVerifyContract.ts'
 import buildWorkflows, { buildWorkflowsFromCommand } from './buildWorkflows.ts'
 import {
     DefaultChainList,
@@ -1116,6 +1124,143 @@ const serveAccountBalance = async (env: IHreContext) => {
     await serveNetworkSelector(env, '', '', getAccountBalance, undefined, false)
 }
 
+interface VerifyContractSourceAnswer {
+    source: string
+}
+interface VerifyContractDeployedAnswer {
+    contractName: string
+}
+interface VerifyContractAddressAnswer {
+    address: string
+}
+interface VerifyContractArgsAnswer {
+    provideArgs: string
+    constructorArgs: string
+}
+
+const VERIFY_SOURCE_ADDRESS_BOOK = 'Pick a contract from the address book'
+const VERIFY_SOURCE_MANUAL = 'Enter a contract address manually'
+const VERIFY_PROVIDE_ARGS_YES = 'yes'
+const VERIFY_PROVIDE_ARGS_NO = 'no'
+
+/**
+ * Interactive "Verify a contract" flow.
+ *
+ * Steps:
+ *   1. Pick a network from the activated chain list (matches the selector
+ *      used by `serveAccountBalance` so the user already knows the layout).
+ *   2. Pick the source: address-book entry or manual address.
+ *   3. Resolve the address.
+ *   4. Optionally provide constructor arguments (comma-separated).
+ *   5. Run `npx hardhat verify <address> --network <network> [<args>...]`.
+ *
+ * The function delegates parsing, validation, and command construction to
+ * `buildVerifyContract.ts` so the CLI flag dispatcher and the menu share
+ * the same code path.
+ */
+const serveVerifyContractSelector = async (env: IHreContext) => {
+    const activatedChainListFromFile: IChain[] = await buildActivatedChainList()
+    const { chains: ActivatedChainList, names: activatedChainList } = buildNetworkSelectorChoices(
+        activatedChainListFromFile,
+        // Local hardhat networks don't have a block explorer — skipping
+        // them keeps the menu from offering a verify command that would
+        // fail at the explorer API.
+        true
+    )
+    if (ActivatedChainList.length === 0) {
+        console.log(
+            '\x1b[33m%s\x1b[0m',
+            'No network activated. Activate a chain with --addActivatedChain first or via the "Setup chains, RPC and accounts" menu before verifying a contract.'
+        )
+        return
+    }
+    const networkSelected: NetworkChoiceAnswer = await inquirer.prompt<NetworkChoiceAnswer>([
+        {
+            type: 'list',
+            name: 'network',
+            message: 'Select the network the contract was deployed to',
+            choices: activatedChainList
+        }
+    ])
+    const selectedChain = ActivatedChainList.find((chain: IChain) => chain.name === networkSelected.network)
+    if (!selectedChain) return
+    const chainShortName = resolveChainShortName(selectedChain, ActivatedChainList)
+
+    const deployedEntries = listDeployedContractsForNetwork(chainShortName, env.userConfig)
+    const sourceChoices = [VERIFY_SOURCE_MANUAL]
+    if (deployedEntries.length > 0) sourceChoices.unshift(VERIFY_SOURCE_ADDRESS_BOOK)
+    const sourceAnswer: VerifyContractSourceAnswer = await inquirer.prompt<VerifyContractSourceAnswer>([
+        {
+            type: 'list',
+            name: 'source',
+            message: 'How do you want to identify the contract?',
+            choices: sourceChoices
+        }
+    ])
+
+    let contractNameOrAddress = ''
+    let resolvedAddress = ''
+    if (sourceAnswer.source === VERIFY_SOURCE_ADDRESS_BOOK) {
+        const contractChoices = deployedEntries.map((entry) => entry.name)
+        const picked: VerifyContractDeployedAnswer = await inquirer.prompt<VerifyContractDeployedAnswer>([
+            {
+                type: 'list',
+                name: 'contractName',
+                message: 'Select a contract from the address book',
+                choices: contractChoices
+            }
+        ])
+        contractNameOrAddress = picked.contractName
+        const resolved = deployedEntries.find((entry) => entry.name === picked.contractName)
+        resolvedAddress = resolved?.address ?? ''
+    } else {
+        const addressAnswer: VerifyContractAddressAnswer = await inquirer.prompt<VerifyContractAddressAnswer>([
+            {
+                type: 'input',
+                name: 'address',
+                message: 'Enter the deployed contract address (0x…)',
+                validate: (input: string) =>
+                    isEthereumAddress(input) || 'Please enter a valid 0x-prefixed 40-hex-character address'
+            }
+        ])
+        contractNameOrAddress = addressAnswer.address.trim()
+        resolvedAddress = contractNameOrAddress
+    }
+
+    const argsAnswer: VerifyContractArgsAnswer = await inquirer.prompt<VerifyContractArgsAnswer>([
+        {
+            type: 'list',
+            name: 'provideArgs',
+            message: 'Do you need to pass constructor arguments?',
+            choices: [VERIFY_PROVIDE_ARGS_NO, VERIFY_PROVIDE_ARGS_YES]
+        }
+    ])
+    let constructorArgs: string[] = []
+    if (argsAnswer.provideArgs === VERIFY_PROVIDE_ARGS_YES) {
+        const argsInput: VerifyContractArgsAnswer = await inquirer.prompt<VerifyContractArgsAnswer>([
+            {
+                type: 'input',
+                name: 'constructorArgs',
+                message: 'Comma-separated constructor arguments (e.g. 0xToken,42)'
+            }
+        ])
+        constructorArgs = argsInput.constructorArgs
+            .split(',')
+            .map((arg: string) => arg.trim())
+            .filter((arg: string) => arg.length > 0)
+    }
+
+    displayFinalCliCommand(
+        'verifyContract',
+        formatVerifyContractFlag(chainShortName, contractNameOrAddress, constructorArgs)
+    )
+    await runVerifyContract({
+        network: chainShortName,
+        contractNameOrAddress,
+        constructorArgs
+    })
+}
+
 /**
  * Raw option strings accepted by the `cli` Hardhat task. All fields default
  * to the empty string at the task-definition site; boolean-shaped flags like
@@ -1142,6 +1287,7 @@ interface ICliArgs {
     runCustomCommand?: string
     addCustomCommand?: string
     removeCustomCommand?: string
+    verifyContract?: string
 }
 
 const serveInquirer = async (env: IHreContext) => {
@@ -1182,6 +1328,7 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P      'Y88P' Y8
         // 'Deploy all contracts and run tests',
         inquirerRunMockContractCreator,
         'Create deployment scripts',
+        'Verify a contract',
         'Get account balance',
         new inquirer.Separator(),
         inquirerFileContractsAddressDeployed,
@@ -1206,6 +1353,7 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P      'Y88P' Y8
     if (answers.action === 'More settings') await serveMoreSettingSelector(env)
     if (answers.action === 'Create Mock contracts') await serveMockContractCreatorSelector()
     if (answers.action === 'Create deployment scripts') await serveDeploymentContractCreatorSelector()
+    if (answers.action === 'Verify a contract') await serveVerifyContractSelector(env)
     if (answers.action === 'Get account balance') await serveAccountBalance(env)
     if (answers.action === 'Run a custom command') await serveRunCustomCommandSelector()
 }
@@ -1337,6 +1485,21 @@ const serveCli = async (args: ICliArgs, env: IHreContext) => {
                 return
             }
             return displayFinalCliCommand('removeCustomCommand', args.removeCustomCommand)
+        }
+        case isPresentString(args.verifyContract): {
+            const parsed = parseVerifyContractFlag(args.verifyContract)
+            if (!parsed) {
+                console.log(
+                    '\x1b[33m%s\x1b[0m',
+                    'Invalid --verifyContract value. Expected "<network>:<contractNameOrAddress>[:<arg1>:<arg2>:...].'
+                )
+                return
+            }
+            return runVerifyContract({
+                network: parsed.network,
+                contractNameOrAddress: parsed.contractNameOrAddress,
+                constructorArgs: parsed.constructorArgs
+            })
         }
         default:
             return serveInquirer(env)

--- a/test/buildVerifyContract.test.ts
+++ b/test/buildVerifyContract.test.ts
@@ -1,0 +1,257 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import {
+    buildVerifyCommand,
+    formatVerifyContractFlag,
+    isEthereumAddress,
+    listDeployedContractsForNetwork,
+    loadDeployedContracts,
+    parseVerifyContractFlag,
+    resolveContractAddress,
+    resolveChainShortName
+} from '../src/buildVerifyContract.ts'
+import { DefaultChainList } from '../src/config.ts'
+import type { IChain } from '../src/types.ts'
+
+const SAMPLE_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678'
+const OTHER_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+
+const findChain = (chainName: string): IChain => {
+    const chain = DefaultChainList.find((entry: IChain) => entry.chainName === chainName)
+    if (!chain) throw new Error(`Test fixture missing default chain "${chainName}"`)
+    return chain
+}
+
+describe('buildVerifyContract (issue #170)', function () {
+    const initialCwd = process.cwd()
+    let fixtureDirectory: string
+
+    beforeEach(function () {
+        fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-verify-'))
+        process.chdir(fixtureDirectory)
+    })
+
+    afterEach(function () {
+        process.chdir(initialCwd)
+        fs.rmSync(fixtureDirectory, { recursive: true, force: true })
+    })
+
+    describe('isEthereumAddress', function () {
+        it('Accepts a checksummed 0x-prefixed address', function () {
+            expect(isEthereumAddress(SAMPLE_ADDRESS)).to.equal(true)
+        })
+
+        it('Accepts an upper-case 0x-prefixed address', function () {
+            expect(isEthereumAddress(SAMPLE_ADDRESS.toUpperCase())).to.equal(true)
+        })
+
+        it('Accepts an address without the 0x prefix', function () {
+            expect(isEthereumAddress(SAMPLE_ADDRESS.slice(2))).to.equal(true)
+        })
+
+        it('Rejects too-short values', function () {
+            expect(isEthereumAddress('0x1234')).to.equal(false)
+        })
+
+        it('Rejects non-hex characters', function () {
+            expect(isEthereumAddress('0xZZZZ567890abcdef1234567890abcdef12345678')).to.equal(false)
+        })
+
+        it('Rejects empty string', function () {
+            expect(isEthereumAddress('')).to.equal(false)
+        })
+
+        it('Rejects non-string values', function () {
+            expect(isEthereumAddress(undefined as any)).to.equal(false)
+            expect(isEthereumAddress(42 as any)).to.equal(false)
+        })
+    })
+
+    describe('buildVerifyCommand', function () {
+        it('Builds the no-arg command with --network before the address', function () {
+            const command = buildVerifyCommand('ethereumSepolia', SAMPLE_ADDRESS)
+            expect(command).to.equal(`npx hardhat verify ${SAMPLE_ADDRESS} --network ethereumSepolia`)
+        })
+
+        it('Quoted constructor arguments are appended after --network', function () {
+            const command = buildVerifyCommand('ethereumSepolia', SAMPLE_ADDRESS, [
+                '0xToken',
+                '42'
+            ])
+            expect(command).to.equal(
+                `npx hardhat verify ${SAMPLE_ADDRESS} --network ethereumSepolia '0xToken' '42'`
+            )
+        })
+
+        it('Empty constructor args drop the trailing whitespace', function () {
+            const command = buildVerifyCommand('ethereumSepolia', SAMPLE_ADDRESS, [])
+            expect(command.endsWith('--network ethereumSepolia')).to.equal(true)
+        })
+    })
+
+    describe('formatVerifyContractFlag / parseVerifyContractFlag', function () {
+        it('Round-trips a network + name without constructor args', function () {
+            const formatted = formatVerifyContractFlag('ethereumSepolia', 'MockERC20')
+            expect(formatted).to.equal('ethereumSepolia:MockERC20')
+            const parsed = parseVerifyContractFlag(formatted)
+            expect(parsed).to.deep.equal({
+                network: 'ethereumSepolia',
+                contractNameOrAddress: 'MockERC20',
+                constructorArgs: []
+            })
+        })
+
+        it('Round-trips a network + address + constructor args', function () {
+            const formatted = formatVerifyContractFlag('ethereumSepolia', SAMPLE_ADDRESS, [
+                '0xToken',
+                '42'
+            ])
+            expect(formatted).to.equal(`ethereumSepolia:${SAMPLE_ADDRESS}:0xToken:42`)
+            const parsed = parseVerifyContractFlag(formatted)
+            expect(parsed).to.deep.equal({
+                network: 'ethereumSepolia',
+                contractNameOrAddress: SAMPLE_ADDRESS,
+                constructorArgs: ['0xToken', '42']
+            })
+        })
+
+        it('Returns undefined for empty / malformed input', function () {
+            expect(parseVerifyContractFlag(undefined)).to.equal(undefined)
+            expect(parseVerifyContractFlag('')).to.equal(undefined)
+            expect(parseVerifyContractFlag('only-one-segment')).to.equal(undefined)
+        })
+    })
+
+    describe('loadDeployedContracts / resolveContractAddress', function () {
+        it('Returns an empty list when the address book file is missing', function () {
+            expect(loadDeployedContracts()).to.deep.equal([])
+        })
+
+        it('Returns an empty list when the file is unparseable JSON', function () {
+            fs.writeFileSync('contractsAddressDeployed.json', '{ not json')
+            expect(loadDeployedContracts()).to.deep.equal([])
+        })
+
+        it('Loads entries from the address book', function () {
+            fs.writeFileSync(
+                'contractsAddressDeployed.json',
+                JSON.stringify([
+                    {
+                        name: 'MockERC20',
+                        address: SAMPLE_ADDRESS,
+                        network: 'ethereumSepolia',
+                        deployer: OTHER_ADDRESS,
+                        deploymentDate: '2026-01-01T00:00:00.000Z',
+                        chainId: 11155111,
+                        blockHash: '',
+                        blockNumber: 0,
+                        tag: '',
+                        extra: {}
+                    }
+                ])
+            )
+            const entries = loadDeployedContracts()
+            expect(entries).to.deep.equal([
+                { name: 'MockERC20', address: SAMPLE_ADDRESS, network: 'ethereumSepolia' }
+            ])
+        })
+
+        it('resolveContractAddress returns the address for the matching network', function () {
+            fs.writeFileSync(
+                'contractsAddressDeployed.json',
+                JSON.stringify([
+                    {
+                        name: 'MockERC20',
+                        address: SAMPLE_ADDRESS,
+                        network: 'ethereumSepolia',
+                        deployer: OTHER_ADDRESS,
+                        deploymentDate: '2026-01-01T00:00:00.000Z',
+                        chainId: 11155111,
+                        blockHash: '',
+                        blockNumber: 0,
+                        tag: '',
+                        extra: {}
+                    }
+                ])
+            )
+            expect(resolveContractAddress('MockERC20', 'ethereumSepolia')).to.equal(SAMPLE_ADDRESS)
+        })
+
+        it('resolveContractAddress returns undefined when the network does not match', function () {
+            fs.writeFileSync(
+                'contractsAddressDeployed.json',
+                JSON.stringify([
+                    {
+                        name: 'MockERC20',
+                        address: SAMPLE_ADDRESS,
+                        network: 'ethereumSepolia',
+                        deployer: OTHER_ADDRESS,
+                        deploymentDate: '2026-01-01T00:00:00.000Z',
+                        chainId: 11155111,
+                        blockHash: '',
+                        blockNumber: 0,
+                        tag: '',
+                        extra: {}
+                    }
+                ])
+            )
+            expect(resolveContractAddress('MockERC20', 'ethereum')).to.equal(undefined)
+        })
+
+        it('resolveContractAddress returns undefined when the contract name is unknown', function () {
+            expect(resolveContractAddress('Unknown', 'ethereumSepolia')).to.equal(undefined)
+        })
+
+        it('listDeployedContractsForNetwork filters entries by network', function () {
+            fs.writeFileSync(
+                'contractsAddressDeployed.json',
+                JSON.stringify([
+                    {
+                        name: 'MockERC20',
+                        address: SAMPLE_ADDRESS,
+                        network: 'ethereumSepolia',
+                        deployer: OTHER_ADDRESS,
+                        deploymentDate: '2026-01-01T00:00:00.000Z',
+                        chainId: 11155111,
+                        blockHash: '',
+                        blockNumber: 0,
+                        tag: '',
+                        extra: {}
+                    },
+                    {
+                        name: 'MockERC721',
+                        address: OTHER_ADDRESS,
+                        network: 'ethereum',
+                        deployer: OTHER_ADDRESS,
+                        deploymentDate: '2026-01-01T00:00:00.000Z',
+                        chainId: 1,
+                        blockHash: '',
+                        blockNumber: 0,
+                        tag: '',
+                        extra: {}
+                    }
+                ])
+            )
+            const sepoliaOnly = listDeployedContractsForNetwork('ethereumSepolia')
+            expect(sepoliaOnly).to.have.length(1)
+            expect(sepoliaOnly[0].name).to.equal('MockERC20')
+        })
+    })
+
+    describe('resolveChainShortName', function () {
+        it('Returns the chain short-name from the activated chain list when found', function () {
+            const chain = findChain('ethereumSepolia')
+            const shortName = resolveChainShortName(chain, [chain])
+            expect(shortName).to.equal('ethereumSepolia')
+        })
+
+        it('Falls back to the chain entry chainName when the activated list is empty', function () {
+            const chain = findChain('ethereumSepolia')
+            const shortName = resolveChainShortName(chain, [])
+            expect(shortName).to.equal('ethereumSepolia')
+        })
+    })
+})


### PR DESCRIPTION
## Summary

Adds a `Verify a contract` menu entry and matching `--verifyContract <network>:<contractNameOrAddress>[:<arg1>:<arg2>:...]` CLI flag so users can verify a deployed contract from the interactive CLI or from a CI script. Closes #170.

## What's new

- **New `src/buildVerifyContract.ts` module** — owns address validation, address-book lookup, command construction, and the CLI flag formatter/parser. The verify plugin check (`@nomicfoundation/hardhat-verify` / `hardhat-verify` in `package.json`) lives here too so the menu and the flag dispatcher share the same code path.
- **Menu entry** — `Verify a contract` sits next to `Create deployment scripts` and walks through network selection, source (address book or manual `0x` address), and optional constructor arguments before running `npx hardhat verify <address> --network <network> [args...]`.
- **CLI flag** — `--verifyContract <network>:<contractNameOrAddress>[:<arg1>:<arg2>:...]`. Falls back to the address book when the second segment is a contract name rather than a `0x` address. Prints an install hint rather than failing at the explorer API when no verify plugin is detected.

## Verification

- `npm run lint` ✅
- `npm run build` ✅
- `npm test` ✅ (266 passing — 22 new tests covering address validation, command builder, flag helpers, address-book loader, and chain short-name resolution)

## Files changed

- `src/buildVerifyContract.ts` (new, 246 lines)
- `src/serveInquirer.ts` (menu wiring + flag dispatch)
- `src/plugin/index.ts` (register the `--verifyContract` task option)
- `test/buildVerifyContract.test.ts` (new, 257 lines)
- `README.md` (document the flow + flag)
- `.changeset/verify-contract.md` (minor bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)