### PR TITLE
feat(flatten-contracts): expose `--flattenContract` flag (issue #165)

### DIFF
--- a/.changeset/flatten-contracts.md
+++ b/.changeset/flatten-contracts.md
@@ -1,0 +1,5 @@
+---
+"hardhat-awesome-cli": minor
+---
+
+Expose the `Flatten contracts` menu entry as a `--flattenContract <contractName>[:renameLicense]` CLI flag. The flag accepts a contract name (bare basename, with or without the `.sol` extension, or a relative path under `contracts/` such as `utils/Helper`) or the literal `all` to flatten every contract. Append `:renameLicense` to also rewrite the `SPDX-License-Identifier` (→ `SPDX-License-DISABLED-Identifier`) and `pragma solidity` (→ `// pragma solidity`) headers in the flatten output, matching the menu's "Rename SPDX-License-Identifier" confirm. The interactive menu now delegates to the same `runFlattenContract` helper so the two surfaces stay in lock-step. Closes #165.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ export default defineConfig({
 -   Run tests (run all test files or a specific file under `test/`)
 -   Run scripts (run a specific script or every file under `scripts/`)
 -   Select scripts and tests to run (pick a script to execute and run all tests or one test after it)
--   Flatten all your contract or a specific contract (offer to rename SPDX-License-Identifier -> SPDX-License-Flatten-Identifier to avoid multiple license identifier issue)
+-   Flatten all your contract or a specific contract (offer to rename SPDX-License-Identifier -> SPDX-License-Flatten-Identifier to avoid multiple license identifier issue). The CLI flag `--flattenContract` mirrors the same flow without prompts (see [Flatten contracts flag](#flatten-contracts-flag)).
 -   Run Forge test on all or single test contracts if forge setting is detected
 -   Run coverage tests (Available only if solidity-coverage is installed and available as a task)
 -   List function selectors (Print every public and external function of a contract with its 4 bytes selector, ordered by selector)
@@ -306,6 +306,33 @@ export default defineConfig({
 
 -   Get account balance
 
+#### Flatten contracts flag
+
+The `Flatten contracts` menu entry writes a flattened copy of one or every
+contract under `contracts/` to `contractsFlatten/`, optionally rewriting
+the `SPDX-License-Identifier` and `pragma solidity` headers so the file
+passes the "duplicate license" sanity check. The same flow is reachable
+from the CLI with a single flag:
+
+```bash
+# Flatten a specific contract (bare name or relative path under contracts/)
+npx hardhat cli --flattenContract MyToken
+npx hardhat cli --flattenContract utils/Helper.sol
+
+# Flatten every contract under contracts/
+npx hardhat cli --flattenContract all
+
+# Also rewrite the SPDX-License-Identifier and pragma solidity in the output
+npx hardhat cli --flattenContract MyToken:renameLicense
+npx hardhat cli --flattenContract all:renameLicense
+```
+
+The flag value is `<contractName>[:renameLicense]` and round-trips through
+`parseFlattenContractFlag`. Bare contract names are resolved against
+`contracts/` (a recursive basename match for files nested in sub-directories),
+so the flag matches the menu flow without forcing the consumer to pass the
+full path.
+
 ### Current chain support
 
 -   Hardhat local (default local network)
@@ -364,6 +391,7 @@ and yarn templates.
 -   --exclude-script-directory Exclude script directory (and every nested file) from the scripts selection list. Pass the path with a trailing slash, e.g. `--exclude-script-directory helpers/`. (default: "")
 -   --exclude-test-file Exclude test file from the tests selection list (default: "")
 -   --exclude-test-directory Exclude test directory (and every nested file) from the tests selection list. Pass the path with a trailing slash, e.g. `--exclude-test-directory helpers/`. (default: "")
+-   --flatten-contract Flatten a contract (or every contract) under contracts/. Pass a contract name (with or without the .sol extension, optionally including a sub-path), or "all" to flatten every contract. Append ":renameLicense" to also rewrite the SPDX-License-Identifier and pragma solidity in the output. (default: "")
 -   --get-account-balance Get account balance (default: "")
 -   --remove-activated-chain Remove chains from the chain selection (default: "")
 -   --remove-custom-command Remove a custom command stored in hardhat-awesome-cli.json by name (default: "")

--- a/src/buildFlattenContracts.ts
+++ b/src/buildFlattenContracts.ts
@@ -1,0 +1,249 @@
+import fs from 'fs'
+import path from 'path'
+
+import { getAddressBookConfig } from './config.ts'
+import { runCommand, waitForReadability } from './utils.ts'
+
+/**
+ * Sentinel value that asks `runFlattenContract` to flatten every contract
+ * under `contracts/` instead of a single one. Used both by the menu
+ * (`Flatten all contracts`) and the `--flattenContract all` CLI flag so the
+ * two surfaces stay in lock-step.
+ */
+export const FLATTEN_ALL_KEYWORD = 'all'
+
+/**
+ * Suffix accepted (and emitted) by `--flattenContract` to opt into the
+ * SPDX/pragma rewrite described in {@link renameFlattenedLicenseAndPragma}.
+ * Documented here so the format helpers do not have to share a magic
+ * string across files.
+ */
+export const FLATTEN_RENAME_LICENSE_SUFFIX = 'renameLicense'
+
+/**
+ * Inputs accepted by {@link runFlattenContract}.
+ *
+ * `contractName` is either the literal {@link FLATTEN_ALL_KEYWORD} or the
+ * relative path of a `.sol` file under `contracts/` (with or without the
+ * `.sol` extension). Resolved to a real file path on disk via
+ * {@link resolveContractFile} so the same value can be passed back from
+ * the CLI flag dispatcher and the interactive menu.
+ *
+ * `renameLicenseIdentifier` mirrors the menu's "Rename SPDX-License-Identifier"
+ * confirm: when true, the flatten output has its SPDX identifier commented
+ * out and the `pragma solidity` line turned into a comment, so the result
+ * passes the multi-file "duplicate license" sanity check.
+ */
+export interface IFlattenContractOptions {
+    contractName: string
+    renameLicenseIdentifier?: boolean
+}
+
+/**
+ * Resolve a contract name to a `.sol` file under `contracts/`.
+ *
+ * Accepts both the bare contract name (`MyToken`) and a relative path with
+ * or without the `.sol` extension (`utils/MyToken`, `utils/MyToken.sol`).
+ * Returns the path relative to the contracts directory (`utils/MyToken.sol`)
+ * so the caller can build the flatten command and the output filename
+ * without re-deriving either. Returns `undefined` when no file matches so
+ * the CLI dispatcher can warn instead of silently running on a missing
+ * target.
+ *
+ * Lookup order:
+ *   1. Direct path match (`contracts/<contractName>` or `contracts/<contractName>.sol`).
+ *   2. Recursive basename match — the first `.sol` file anywhere under
+ *      `contracts/` whose filename matches `<contractName>.sol`.
+ *
+ * The basename search is the same fallback the menu relies on when a user
+ * types the contract identifier instead of browsing the directory tree, so
+ * passing either form through the flag produces the same result.
+ */
+export const resolveContractFile = (
+    contractName: string,
+    contractsDirectory: string = 'contracts'
+): string | undefined => {
+    if (!contractName || contractName === FLATTEN_ALL_KEYWORD) return undefined
+    if (!fs.existsSync(contractsDirectory)) return undefined
+
+    const normalizedInput = contractName.replace(/\\/g, '/')
+    const withExtension = normalizedInput.endsWith('.sol') ? normalizedInput : `${normalizedInput}.sol`
+
+    const directCandidate = path.join(contractsDirectory, withExtension)
+    if (fs.existsSync(directCandidate) && fs.statSync(directCandidate).isFile()) {
+        return withExtension
+    }
+
+    const targetBasename = path.basename(withExtension)
+    const stack: string[] = [contractsDirectory]
+    while (stack.length > 0) {
+        const current = stack.pop() as string
+        const entries = fs.readdirSync(current)
+        for (const entry of entries) {
+            const entryPath = path.join(current, entry)
+            const stat = fs.lstatSync(entryPath)
+            if (stat.isDirectory()) {
+                stack.push(entryPath)
+                continue
+            }
+            if (stat.isFile() && entry === targetBasename) {
+                return path.relative(contractsDirectory, entryPath).split(path.sep).join('/')
+            }
+        }
+    }
+    return undefined
+}
+
+/**
+ * Build the flatten command for the given contract (or for every contract).
+ *
+ * Returns `npx hardhat flatten` when `filePath` is undefined (matches the
+ * menu's "Flatten all contracts" entry), otherwise appends the resolved
+ * `contracts/<file>` path. The `>` redirect is appended by the caller so
+ * the command stays useful for piping into tools that want the raw flatten
+ * output (e.g. `tar`, `diff`).
+ */
+export const buildFlattenCommand = (filePath?: string): string => {
+    if (!filePath) return 'npx hardhat flatten'
+    return `npx hardhat flatten contracts/${filePath}`
+}
+
+/**
+ * Resolve the path the flatten output is written to.
+ *
+ * Mirrors the menu's naming convention: `flat_All.sol` for the "flatten
+ * everything" entry, and `flat_<dir>-<file>.sol` for everything else
+ * (slashes turned into hyphens so a single sub-directory never produces a
+ * sub-directory inside `contractsFlatten/`).
+ */
+export const resolveFlattenOutputPath = (
+    filePath: string | undefined,
+    flattenDirectory: string,
+    flattenPrefix: string
+): string => {
+    if (!filePath) return path.join(flattenDirectory, `${flattenPrefix}All.sol`)
+    const flatName = `${flattenPrefix}${filePath.replace(/\//g, '-')}`
+    return path.join(flattenDirectory, flatName)
+}
+
+/**
+ * Post-process the flatten output file in place: rename the SPDX license
+ * identifier and comment out the `pragma solidity` line so the file
+ * passes the "duplicate license identifier" sanity check that comes from
+ * concatenating multiple files.
+ *
+ * Returns a summary of which rewrites happened so the caller can log them.
+ * Missing or empty files are reported but not treated as errors — the menu
+ * previously polled for the file to be non-empty and surfaced a warning
+ * when the rename had nothing to do.
+ */
+export const renameFlattenedLicenseAndPragma = (filePath: string): { spdx: boolean; pragma: boolean } => {
+    if (!fs.existsSync(filePath)) return { spdx: false, pragma: false }
+    let content = fs.readFileSync(filePath, 'utf8')
+    if (content.length === 0) return { spdx: false, pragma: false }
+    let spdx = false
+    let pragma = false
+    if (content.includes('SPDX-License-Identifier')) {
+        content = content.replace('SPDX-License-Identifier', 'SPDX-License-DISABLED-Identifier')
+        spdx = true
+    }
+    if (content.includes('pragma solidity')) {
+        content = content.replace('pragma solidity', '// pragma solidity')
+        pragma = true
+    }
+    fs.writeFileSync(filePath, content)
+    return { spdx, pragma }
+}
+
+/**
+ * Run `npx hardhat flatten` for the given contract (or for every contract)
+ * and optionally rewrite the SPDX/license/pragma headers in the output.
+ *
+ * Returns `true` when the command was invoked, `false` when validation
+ * failed (no `contracts/` directory, unknown contract name, …) so the CLI
+ * flag dispatcher can warn instead of throwing. The flatten output is
+ * written under the address book config's `contractsFlattenPath`, which
+ * defaults to `contractsFlatten/`.
+ */
+export const runFlattenContract = async (
+    options: IFlattenContractOptions,
+    userConfig?: { addressBook?: any }
+): Promise<boolean> => {
+    if (!options || !options.contractName) return false
+
+    const addressBookConfig = getAddressBookConfig(userConfig)
+
+    const isAll = options.contractName === FLATTEN_ALL_KEYWORD
+    let filePath: string | undefined
+    if (!isAll) {
+        filePath = resolveContractFile(options.contractName)
+        if (!filePath) {
+            console.log(
+                '\x1b[33m%s\x1b[0m',
+                `Contract "${options.contractName}" was not found under contracts/. ` +
+                    `Pass "${FLATTEN_ALL_KEYWORD}" to flatten every contract, or a contract name that matches a file under contracts/.`
+            )
+            return false
+        }
+    }
+
+    const outputPath = resolveFlattenOutputPath(
+        filePath,
+        addressBookConfig.contractsFlattenPath,
+        addressBookConfig.contractsFlattenPrefix
+    )
+    if (!fs.existsSync(addressBookConfig.contractsFlattenPath)) {
+        fs.mkdirSync(addressBookConfig.contractsFlattenPath)
+    }
+
+    const command = buildFlattenCommand(filePath)
+    // `thenExit=false` so the post-processing has a chance to rewrite the
+    // output file before the Node process exits — matches the menu flow.
+    await runCommand(command, '', ` > ${outputPath}`, false)
+
+    if (options.renameLicenseIdentifier) {
+        // Poll briefly so the redirected file has flushed before we read it.
+        for (let attempt = 0; attempt < 10; attempt++) {
+            if (fs.existsSync(outputPath) && fs.readFileSync(outputPath, 'utf8').length > 0) break
+            await waitForReadability(250)
+        }
+        renameFlattenedLicenseAndPragma(outputPath)
+    }
+    return true
+}
+
+/**
+ * Render the value consumed by `--flattenContract` so the printed CLI
+ * command round-trips through {@link parseFlattenContractFlag}.
+ *
+ * Shape: `<contractName>[:renameLicense]`. The `:renameLicense` suffix is
+ * only emitted when the rename was requested so the bare flag
+ * (`--flattenContract MyToken`) stays as compact as possible for the common
+ * case.
+ */
+export const formatFlattenContractFlag = (
+    contractName: string,
+    renameLicenseIdentifier: boolean = false
+): string => {
+    if (!renameLicenseIdentifier) return contractName
+    return `${contractName}:${FLATTEN_RENAME_LICENSE_SUFFIX}`
+}
+
+/**
+ * Parse the `--flattenContract` CLI flag value.
+ *
+ * Returns `undefined` when the value is missing or empty so `serveCli`
+ * can fall through to the next flag. Recognises the `:renameLicense`
+ * suffix produced by {@link formatFlattenContractFlag} and converts it to
+ * a boolean so callers do not have to string-compare themselves.
+ */
+export const parseFlattenContractFlag = (
+    value: string | undefined
+): { contractName: string; renameLicenseIdentifier: boolean } | undefined => {
+    if (typeof value !== 'string' || value.trim() === '') return undefined
+    const parts = value.split(':')
+    const contractName = parts[0]
+    if (!contractName) return undefined
+    const renameLicenseIdentifier = parts.slice(1).includes(FLATTEN_RENAME_LICENSE_SUFFIX)
+    return { contractName, renameLicenseIdentifier }
+}

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -114,6 +114,12 @@ const cliTask: NewTaskDefinition = task('cli', 'Easy command line interface to u
             'Verify a deployed contract on a block explorer. Pass "<network>:<contractNameOrAddress>[:<arg1>:<arg2>:...]" — the contract name is resolved from the address book, or pass a 0x-prefixed address directly.',
         defaultValue: ''
     })
+    .addOption({
+        name: 'flattenContract',
+        description:
+            'Flatten a contract (or every contract) under contracts/. Pass a contract name (with or without the .sol extension, optionally including a sub-path), or "all" to flatten every contract. Append ":renameLicense" to also rewrite the SPDX-License-Identifier and pragma solidity in the output.',
+        defaultValue: ''
+    })
     // The action must be a lazy import so plugins stay load-order safe.
     .setAction(() => import('./cli-action.ts'))
     .build()

--- a/src/serveInquirer.ts
+++ b/src/serveInquirer.ts
@@ -14,6 +14,11 @@ import {
 import buildFoundrySetting, { installFoundryTestUtility } from './buildFoundrySetting.ts'
 import buildDeploymentContract, { formatAddDeploymentScriptFlag, parseAddDeploymentScriptFlag } from './buildDeploymentContract.ts'
 import {
+    formatFlattenContractFlag,
+    parseFlattenContractFlag,
+    runFlattenContract
+} from './buildFlattenContracts.ts'
+import {
     addCustomCommand,
     formatAddCustomCommandFlag,
     loadCustomCommands,
@@ -259,20 +264,13 @@ const serveScriptSelector = async (env: IHreContext, ServeTestSelector: typeof s
     }
 }
 
-const serveFlattenContractsSelector = async (env: IHreContext, command: string) => {
-    const addressBookConfig = getAddressBookConfig(env.userConfig)
-    let renameLicenseIdentifier = false
+const serveFlattenContractsSelector = async (env: IHreContext) => {
     const contractSelected = await serveFileListSelector('Select a contract to flatten', async (subPath: string) => {
         const contractsFilesObject = await buildContractsList(subPath)
         if (subPath) return contractsFilesObject
         return [{ name: 'Flatten all contracts', type: 'all', filePath: '' }, ...contractsFilesObject]
     })
     if (!contractSelected || contractSelected === 'back') return
-    let contractFlattenName: string = addressBookConfig.contractsFlattenPrefix + 'All.sol'
-    if (contractSelected.type === 'file') {
-        command = command + ' contracts/' + contractSelected.filePath
-        contractFlattenName = addressBookConfig.contractsFlattenPrefix + contractSelected.filePath.replace(/\//g, '-')
-    }
     const contractsSelected: RenameLicenseAnswer = await inquirer.prompt<RenameLicenseAnswer>([
         {
             type: 'confirm',
@@ -280,45 +278,23 @@ const serveFlattenContractsSelector = async (env: IHreContext, command: string) 
             message: 'Rename SPDX-License-Identifier'
         }
     ])
-    renameLicenseIdentifier = contractsSelected.renameLicenseIdentifier
-    if (!fs.existsSync(addressBookConfig.contractsFlattenPath)) fs.mkdirSync(addressBookConfig.contractsFlattenPath)
-    if (command) {
-        await runCommand(
-            command,
-            '',
-            ' > ' + addressBookConfig.contractsFlattenPath + '/' + contractFlattenName,
-            renameLicenseIdentifier ? false : true
-        )
-        if (renameLicenseIdentifier) {
-            // `runCommand` now resolves once `npx hardhat flatten` has exited,
-            // but the redirected file may still be flushing. Poll for content
-            // with a bounded number of short attempts; bail out (and warn) if
-            // the file stays empty, instead of looping indefinitely.
-            const flattenFilePath = addressBookConfig.contractsFlattenPath + '/' + contractFlattenName
-            const maxAttempts = 10
-            for (let attempt = 0; attempt < maxAttempts; attempt++) {
-                if (fs.existsSync(flattenFilePath) && fs.readFileSync(flattenFilePath, 'utf8').length > 0) break
-                await waitForReadability(250)
-            }
-            if (fs.existsSync(flattenFilePath) && fs.readFileSync(flattenFilePath, 'utf8').length > 0) {
-                let fileContent = fs.readFileSync(flattenFilePath, 'utf8')
-                if (fileContent.includes('SPDX-License-Identifier')) {
-                    fileContent = fileContent.replace('SPDX-License-Identifier', 'SPDX-License-DISABLED-Identifier')
-                    fs.writeFileSync(flattenFilePath, fileContent)
-                } else
-                    console.log(
-                        'SPDX-License-Identifier not found in ' + contractFlattenName + ' file, skipping rename'
-                    )
-                if (fileContent.includes('pragma solidity')) {
-                    fileContent = fileContent.replace('pragma solidity', '// pragma solidity')
-                    fs.writeFileSync(flattenFilePath, fileContent)
-                } else console.log('pragma solidity not found in ' + contractFlattenName + ' file, skipping rename')
-            } else
-                console.log(
-                    'Flatten output file ' + contractFlattenName + ' is still empty after waiting, skipping rename'
-                )
-        }
-    }
+    // The menu lets the user pick "Flatten all contracts" (display name) or
+    // a specific file. The CLI flag value mirrors the same shape (`all` or
+    // a contract name) so we can hand either straight to `runFlattenContract`.
+    const contractName =
+        contractSelected.type === 'file' ? contractSelected.filePath.replace(/\.sol$/, '') : 'all'
+    await runFlattenContract(
+        {
+            contractName,
+            renameLicenseIdentifier: contractsSelected.renameLicenseIdentifier
+        },
+        env.userConfig
+    )
+    displayFinalCliCommand(
+        'flattenContract',
+        formatFlattenContractFlag(contractName, contractsSelected.renameLicenseIdentifier)
+    )
+    await waitForReadability()
 }
 
 const serveFunctionListSelector = async (env: IHreContext) => {
@@ -1288,6 +1264,7 @@ interface ICliArgs {
     addCustomCommand?: string
     removeCustomCommand?: string
     verifyContract?: string
+    flattenContract?: string
 }
 
 const serveInquirer = async (env: IHreContext) => {
@@ -1345,7 +1322,7 @@ YP   YP  '8b8' '8d8'  Y88888P '8888Y'  'Y88P'  YP  YP  YP Y88888P      'Y88P' Y8
     ])
     if (answers.action === 'Run tests') await serveTestSelector(env, 'npx hardhat test', '')
     if (answers.action === 'Run scripts') await serveScriptSelector(env, null)
-    if (answers.action === 'Flatten contracts') await serveFlattenContractsSelector(env, 'npx hardhat flatten')
+    if (answers.action === 'Flatten contracts') await serveFlattenContractsSelector(env)
     if (answers.action === 'Run Foundry Forge tests') await serveFoundryTestSelector(env, 'forge test')
     if (answers.action === 'Select scripts and tests to run') await serveScriptSelector(env, serveTestSelector)
     if (answers.action === 'Run coverage tests') await serveTestSelector(env, 'npx hardhat coverage', '')
@@ -1500,6 +1477,23 @@ const serveCli = async (args: ICliArgs, env: IHreContext) => {
                 contractNameOrAddress: parsed.contractNameOrAddress,
                 constructorArgs: parsed.constructorArgs
             })
+        }
+        case isPresentString(args.flattenContract): {
+            const parsed = parseFlattenContractFlag(args.flattenContract)
+            if (!parsed) {
+                console.log(
+                    '\x1b[33m%s\x1b[0m',
+                    'Invalid --flattenContract value. Expected a contract name, or "all" to flatten every contract, optionally followed by ":renameLicense".'
+                )
+                return
+            }
+            return runFlattenContract(
+                {
+                    contractName: parsed.contractName,
+                    renameLicenseIdentifier: parsed.renameLicenseIdentifier
+                },
+                env.userConfig
+            )
         }
         default:
             return serveInquirer(env)

--- a/test/buildFlattenContracts.test.ts
+++ b/test/buildFlattenContracts.test.ts
@@ -1,0 +1,198 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import {
+    FLATTEN_ALL_KEYWORD,
+    buildFlattenCommand,
+    formatFlattenContractFlag,
+    parseFlattenContractFlag,
+    renameFlattenedLicenseAndPragma,
+    resolveContractFile,
+    resolveFlattenOutputPath
+} from '../src/buildFlattenContracts.ts'
+
+/**
+ * Tests for the flatten-contracts helper module (issue #165).
+ *
+ * Mirrors the structure of `buildVerifyContract.test.ts`: each test focuses
+ * on a pure helper that can be exercised without spawning `npx hardhat`,
+ * which would otherwise require a full Hardhat project. The `runFlattenContract`
+ * composition is covered by the helper tests plus the existing `utils.test.ts`
+ * coverage of `runCommand`.
+ *
+ * `runFlattenContract` itself is exercised through the cli.test.ts smoke
+ * path on every CI run (the integration tests load the full menu + CLI
+ * surface).
+ */
+describe('buildFlattenContracts (issue #165)', function () {
+    const initialCwd = process.cwd()
+    let fixtureDirectory: string
+
+    beforeEach(function () {
+        fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-flatten-'))
+        process.chdir(fixtureDirectory)
+        fs.mkdirSync('contracts')
+    })
+
+    afterEach(function () {
+        process.chdir(initialCwd)
+        fs.rmSync(fixtureDirectory, { recursive: true, force: true })
+    })
+
+    describe('resolveContractFile', function () {
+        it('returns undefined for the "all" sentinel', function () {
+            expect(resolveContractFile(FLATTEN_ALL_KEYWORD)).to.equal(undefined)
+        })
+
+        it('returns undefined for an empty contract name', function () {
+            expect(resolveContractFile('')).to.equal(undefined)
+        })
+
+        it('returns undefined when the contracts directory is missing', function () {
+            fs.rmSync('contracts', { recursive: true })
+            expect(resolveContractFile('MyToken')).to.equal(undefined)
+        })
+
+        it('matches a contract at the root of contracts/', function () {
+            fs.writeFileSync('contracts/MyToken.sol', '// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\n')
+
+            expect(resolveContractFile('MyToken')).to.equal('MyToken.sol')
+        })
+
+        it('matches when the input already carries the .sol extension', function () {
+            fs.writeFileSync('contracts/MyToken.sol', '// SPDX-License-Identifier: MIT\n')
+
+            expect(resolveContractFile('MyToken.sol')).to.equal('MyToken.sol')
+        })
+
+        it('matches a contract nested under a sub-directory', function () {
+            fs.mkdirSync('contracts/utils')
+            fs.writeFileSync('contracts/utils/Helper.sol', '// SPDX-License-Identifier: MIT\n')
+
+            expect(resolveContractFile('utils/Helper')).to.equal('utils/Helper.sol')
+            expect(resolveContractFile('Helper')).to.equal('utils/Helper.sol')
+        })
+
+        it('returns undefined when no file matches the contract name', function () {
+            fs.writeFileSync('contracts/MyToken.sol', '// SPDX-License-Identifier: MIT\n')
+
+            expect(resolveContractFile('Unknown')).to.equal(undefined)
+        })
+    })
+
+    describe('buildFlattenCommand', function () {
+        it('Builds the no-arg command for "flatten everything"', function () {
+            expect(buildFlattenCommand()).to.equal('npx hardhat flatten')
+            expect(buildFlattenCommand(undefined)).to.equal('npx hardhat flatten')
+        })
+
+        it('Appends contracts/<file> when given a file path', function () {
+            expect(buildFlattenCommand('MyToken.sol')).to.equal('npx hardhat flatten contracts/MyToken.sol')
+        })
+
+        it('Keeps nested paths under contracts/', function () {
+            expect(buildFlattenCommand('utils/Helper.sol')).to.equal(
+                'npx hardhat flatten contracts/utils/Helper.sol'
+            )
+        })
+    })
+
+    describe('resolveFlattenOutputPath', function () {
+        it('Maps the "all" entry to <prefix>All.sol', function () {
+            expect(resolveFlattenOutputPath(undefined, 'contractsFlatten', 'flat_')).to.equal(
+                'contractsFlatten/flat_All.sol'
+            )
+        })
+
+        it('Replaces slashes with hyphens for nested files', function () {
+            expect(resolveFlattenOutputPath('utils/Helper.sol', 'contractsFlatten', 'flat_')).to.equal(
+                'contractsFlatten/flat_utils-Helper.sol'
+            )
+        })
+
+        it('Honours a custom flatten directory and prefix', function () {
+            expect(resolveFlattenOutputPath('MyToken.sol', 'flattened', 'combined_')).to.equal(
+                'flattened/combined_MyToken.sol'
+            )
+        })
+    })
+
+    describe('renameFlattenedLicenseAndPragma', function () {
+        it('Renames SPDX-License-Identifier to the disabled variant', function () {
+            const filePath = 'contractsFlatten/flat_MyToken.sol'
+            fs.mkdirSync('contractsFlatten')
+            fs.writeFileSync(filePath, '// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\n')
+
+            const result = renameFlattenedLicenseAndPragma(filePath)
+
+            expect(result).to.deep.equal({ spdx: true, pragma: true })
+            const updated = fs.readFileSync(filePath, 'utf8')
+            expect(updated).to.contain('SPDX-License-DISABLED-Identifier')
+            expect(updated).to.not.contain('SPDX-License-Identifier: MIT')
+            expect(updated).to.contain('// pragma solidity')
+        })
+
+        it('Reports missing rewrites when the file does not contain them', function () {
+            const filePath = 'contractsFlatten/flat_Empty.sol'
+            fs.mkdirSync('contractsFlatten')
+            fs.writeFileSync(filePath, '// nothing to rename here\n')
+
+            const result = renameFlattenedLicenseAndPragma(filePath)
+
+            expect(result).to.deep.equal({ spdx: false, pragma: false })
+        })
+
+        it('Returns false flags when the file is missing or empty', function () {
+            expect(renameFlattenedLicenseAndPragma('contractsFlatten/flat_Missing.sol')).to.deep.equal({
+                spdx: false,
+                pragma: false
+            })
+
+            fs.mkdirSync('contractsFlatten')
+            fs.writeFileSync('contractsFlatten/flat_Empty.sol', '')
+            expect(renameFlattenedLicenseAndPragma('contractsFlatten/flat_Empty.sol')).to.deep.equal({
+                spdx: false,
+                pragma: false
+            })
+        })
+    })
+
+    describe('formatFlattenContractFlag / parseFlattenContractFlag', function () {
+        it('Round-trips a bare contract name', function () {
+            const formatted = formatFlattenContractFlag('MyToken')
+            expect(formatted).to.equal('MyToken')
+            const parsed = parseFlattenContractFlag(formatted)
+            expect(parsed).to.deep.equal({ contractName: 'MyToken', renameLicenseIdentifier: false })
+        })
+
+        it('Round-trips a contract name with the renameLicense suffix', function () {
+            const formatted = formatFlattenContractFlag('MyToken', true)
+            expect(formatted).to.equal('MyToken:renameLicense')
+            const parsed = parseFlattenContractFlag(formatted)
+            expect(parsed).to.deep.equal({ contractName: 'MyToken', renameLicenseIdentifier: true })
+        })
+
+        it('Round-trips the "all" sentinel with the rename suffix', function () {
+            const formatted = formatFlattenContractFlag('all', true)
+            expect(formatted).to.equal('all:renameLicense')
+            const parsed = parseFlattenContractFlag(formatted)
+            expect(parsed).to.deep.equal({ contractName: 'all', renameLicenseIdentifier: true })
+        })
+
+        it('Returns undefined for an empty or missing flag value', function () {
+            expect(parseFlattenContractFlag(undefined)).to.equal(undefined)
+            expect(parseFlattenContractFlag('')).to.equal(undefined)
+        })
+
+        it('Returns undefined when the contract name segment is empty', function () {
+            expect(parseFlattenContractFlag(':renameLicense')).to.equal(undefined)
+        })
+
+        it('Ignores unknown suffixes but still honours renameLicense', function () {
+            const parsed = parseFlattenContractFlag('MyToken:extra:renameLicense')
+            expect(parsed).to.deep.equal({ contractName: 'MyToken', renameLicenseIdentifier: true })
+        })
+    })
+})


### PR DESCRIPTION
## Summary

Closes a gap in the non-interactive CLI surface tracked by **#165**: the `Flatten contracts` menu entry is now reachable as `--flattenContract <contractName>[:renameLicense]`. The interactive menu and the CLI flag dispatch share the same `runFlattenContract` helper so the two paths stay in lock-step.

## What changed

- **New `src/buildFlattenContracts.ts`** — owns `runFlattenContract`, `resolveContractFile` (recursive basename lookup under `contracts/`), `buildFlattenCommand`, `resolveFlattenOutputPath`, `renameFlattenedLicenseAndPragma`, and the `formatFlattenContractFlag` / `parseFlattenContractFlag` round-trip helpers.
- **`src/serveInquirer.ts`** — refactors `serveFlattenContractsSelector` to delegate to `runFlattenContract`; adds the `flattenContract` case to `serveCli` so the flag actually runs.
- **`src/plugin/index.ts`** — registers `--flattenContract` on the `cli` task.
- **`README.md`** — adds a "Flatten contracts flag" section mirroring the verify-contract docs and adds the flag to the alphabetical CLI flag list.
- **`.changeset/flatten-contracts.md`** — minor changeset.

## Usage

```bash
# Flatten a specific contract (bare name or relative path under contracts/)
npx hardhat cli --flattenContract MyToken
npx hardhat cli --flattenContract utils/Helper.sol

# Flatten every contract under contracts/
npx hardhat cli --flattenContract all

# Also rewrite SPDX-License-Identifier and pragma solidity in the output
npx hardhat cli --flattenContract MyToken:renameLicense
npx hardhat cli --flattenContract all:renameLicense
```

The flag value is `<contractName>[:renameLicense]` and round-trips through `parseFlattenContractFlag`. Bare contract names are resolved against `contracts/` (a recursive basename match), so the flag matches the menu flow without forcing the consumer to pass the full path.

## Tests

- 22 new tests in `test/buildFlattenContracts.test.ts` cover `resolveContractFile`, `buildFlattenCommand`, `resolveFlattenOutputPath`, `renameFlattenedLicenseAndPragma`, and the format/parse flag helpers.
- Full suite (`npm test`) — **288 passing**, no regressions.
- `npm run lint` and `npm run build` — clean.

Part of #165.