### PR TITLE
feat: expose "Add a custom chain" menu entry as --addCustomChain CLI flag

### DIFF
--- a/.changeset/add-custom-chain.md
+++ b/.changeset/add-custom-chain.md
@@ -1,0 +1,5 @@
+---
+"hardhat-awesome-cli": minor
+---
+
+Expose the "Add a custom chain to the current chain selection" sub-flow as a `--addCustomChain` CLI flag. The flag accepts a JSON object with `name` (string), `chainId` (positive integer), optional `gas` (defaults to `"auto"`), and optional `defaultRpcUrl`. The internal `chainName` slot (`customChain1`..`customChain8`) is picked automatically by `buildCustomChainEntry` so both the menu and the CLI stay in lock-step. The interactive "Add a custom chain" sub-flow now delegates to the same `runAddCustomChain` helper that backs the flag, picking the next free slot instead of the previous (broken) "first already-used" lookup. Closes #165.

--- a/README.md
+++ b/README.md
@@ -333,6 +333,30 @@ The flag value is `<contractName>[:renameLicense]` and round-trips through
 so the flag matches the menu flow without forcing the consumer to pass the
 full path.
 
+#### Add a custom chain flag
+
+The "Add a custom chain to the current chain selection" sub-flow writes a new
+entry to `hardhat-awesome-cli.json` under the next free `customChain{N}`
+slot (1..8). The same flow is reachable from the CLI with a single flag:
+
+```bash
+# Minimal payload — name + chainId, gas defaults to "auto"
+npx hardhat cli --addCustomChain '{"name":"My Chain","chainId":7777}'
+
+# Fully-specified payload — gas override + default RPC URL
+npx hardhat cli --addCustomChain '{"name":"My Chain","chainId":7777,"gas":"auto","defaultRpcUrl":"https://rpc.example.invalid"}'
+```
+
+The flag value is a JSON object with the user-visible fields (`name`,
+`chainId`, optional `gas`, optional `defaultRpcUrl`). The internal
+`chainName` slot is assigned automatically by `buildCustomChainEntry`, so
+both surfaces stay in lock-step and re-running the flag without a removal
+step just rolls over to the next free slot. `runAddCustomChain` returns
+`false` (and prints a yellow warning, mirroring the menu) when the input
+fails validation, every slot is already taken, or the chain collides with an
+existing default / activated chain — same as the menu, so the CLI dispatcher
+can surface failure without throwing.
+
 ### Current chain support
 
 -   Hardhat local (default local network)
@@ -379,6 +403,7 @@ and yarn templates.
 ## CLI optional flags
 
 -   --add-activated-chain Add chains from the chain selection (default: "")
+-   --add-custom-chain Add a custom chain to the user's activated chain list. Pass a JSON object {"name":"...","chainId":<int>,"gas":"auto","defaultRpcUrl":"..."}. The chainName slot (customChain1..customChain8) is picked automatically; gas defaults to "auto" and defaultRpcUrl is optional. (default: "")
 -   --add-custom-command Add a custom command to hardhat-awesome-cli.json. Pass a JSON object {"name":"...","description":"...","kind":"shell|hardhat","command":"..."}. (default: "")
 -   --add-deployment-script Scaffold a deployment script for the named contract. Pass the contract name, optionally followed by ":"-separated constructor arguments, e.g. "<ContractName>:<arg1>:<arg2>". (default: "")
 -   --add-foundry Create Foundry settings, remapping and test utilities (default: "")

--- a/src/buildNetworks.ts
+++ b/src/buildNetworks.ts
@@ -179,23 +179,199 @@ export const removeActivatedChain = async (chainName: string) => {
     }
 }
 
+/**
+ * Public input shape for the `--addCustomChain` CLI flag (and the helper that
+ * backs it). Only carries the user-visible fields — the internal `chainName`
+ * slot (`customChain1` … `customChain8`) is assigned automatically by
+ * {@link buildCustomChainEntry} so the menu and the flag surface stay in
+ * lock-step.
+ */
+export interface IAddCustomChainInput {
+    name: string
+    chainId: number
+    gas?: string
+    defaultRpcUrl?: string
+}
+
+/**
+ * Find the first free `customChain{N}` slot (1..8) in the activated chain
+ * list. Returns `undefined` when every slot is already taken, so the caller
+ * can warn instead of silently overwriting an existing custom chain.
+ *
+ * Slots are picked in ascending order so re-running the menu / CLI flag
+ * without a removal step produces deterministic slot assignments.
+ */
+export const findAvailableCustomChainSlot = async (): Promise<string | undefined> => {
+    const activatedChainList = await buildActivatedChainList()
+    for (let i = 1; i <= 8; i++) {
+        const candidate = `customChain${i}`
+        if (!activatedChainList.find((chain: IChain) => chain.chainName === candidate)) {
+            return candidate
+        }
+    }
+    return undefined
+}
+
+/**
+ * Build the {@link IChain} entry to persist when adding a custom chain
+ * through the menu or the `--addCustomChain` CLI flag.
+ *
+ * Picks the next free `customChain{N}` slot (1..8) automatically, so the
+ * caller only supplies user-visible fields. Returns `undefined` when:
+ *   - the input is missing or not an object
+ *   - `name` is empty after trimming
+ *   - `chainId` is missing or not a positive integer
+ *   - every `customChain{N}` slot is already in use
+ *
+ * Defaults `gas` to `'auto'` (the menu's own default) and drops
+ * `defaultRpcUrl` when blank so the persisted entry matches what a fresh
+ * menu interaction would write.
+ */
+export const buildCustomChainEntry = async (details: IAddCustomChainInput): Promise<IChain | undefined> => {
+    if (!details || typeof details !== 'object') return undefined
+    const name = typeof details.name === 'string' ? details.name.trim() : ''
+    const rawChainId = typeof details.chainId === 'number' ? details.chainId : Number(details.chainId)
+    if (!name) return undefined
+    if (!Number.isFinite(rawChainId) || !Number.isInteger(rawChainId) || rawChainId <= 0) return undefined
+    const gas = typeof details.gas === 'string' && details.gas.trim() !== '' ? details.gas.trim() : 'auto'
+    const defaultRpcUrl =
+        typeof details.defaultRpcUrl === 'string' && details.defaultRpcUrl.trim() !== ''
+            ? details.defaultRpcUrl.trim()
+            : undefined
+
+    const chainName = await findAvailableCustomChainSlot()
+    if (!chainName) return undefined
+
+    const entry: IChain = {
+        name,
+        chainName,
+        chainId: rawChainId,
+        gas
+    }
+    if (defaultRpcUrl) entry.defaultRpcUrl = defaultRpcUrl
+    return entry
+}
+
+/**
+ * Print the conflict warning that {@link runAddCustomChain} uses when the
+ * supplied chain collides with an existing entry. Kept as a small helper so
+ * the test suite can verify the exact message without re-implementing it.
+ */
+const CHAIN_CONFLICT_MESSAGES: Record<string, string> = {
+    defaultShortName: 'Chain with same Short-Name already exists in regular chain selection',
+    defaultChainId: 'Chain with same chainId already exists in regular chain selection',
+    activatedShortName: 'Chain with same Short-Name already exists in your settings activated chain list',
+    activatedChainId: 'Chain with same chainId already exists in your settings activated chain list'
+}
+
 export const addCustomChain = async (chainDetails: IChain) => {
     const FullChainList = DefaultChainList
     const ActivatedChainList = await buildActivatedChainList()
     // Verify if the chain already exists in regular full chain list
     if (FullChainList.find((chain: IChain) => chain.chainName === chainDetails.chainName))
-        console.log('\x1b[33m%s\x1b[0m', 'Chain with same Short-Name already exists in regular chain selection')
+        console.log('\x1b[33m%s\x1b[0m', CHAIN_CONFLICT_MESSAGES.defaultShortName)
     else if (FullChainList.find((chain: IChain) => chain.chainId === chainDetails.chainId))
-        console.log('\x1b[33m%s\x1b[0m', 'Chain with same chainId already exists in regular chain selection')
+        console.log('\x1b[33m%s\x1b[0m', CHAIN_CONFLICT_MESSAGES.defaultChainId)
     // Verify if the chain already exists in user setting activated chain list
     else if (ActivatedChainList.find((chain: IChain) => chain.chainName === chainDetails.chainName))
+        console.log('\x1b[33m%s\x1b[0m', CHAIN_CONFLICT_MESSAGES.activatedShortName)
+    else if (ActivatedChainList.find((chain: IChain) => chain.chainId === chainDetails.chainId))
+        console.log('\x1b[33m%s\x1b[0m', CHAIN_CONFLICT_MESSAGES.activatedChainId)
+    else await addChain(chainDetails.chainName, chainDetails)
+}
+
+/**
+ * Add a custom chain to the user's activated chain list, picking the
+ * `customChain{N}` slot automatically. Returns `true` when the chain was
+ * persisted, `false` when:
+ *   - the input fails validation (missing name, non-positive chainId, …)
+ *   - every `customChain{N}` slot is already in use
+ *   - the chain collides with an existing default or activated chain
+ *
+ * The `false` return + yellow warning mirrors the existing menu behaviour so
+ * the CLI dispatcher can flag the failure without throwing, matching how
+ * `addCustomMockContract` and `addActivatedChain` already report failure to
+ * the user. Closes the "Add a custom chain to the current chain selection"
+ * menu sub-flow for non-interactive use.
+ */
+export const runAddCustomChain = async (details: IAddCustomChainInput): Promise<boolean> => {
+    const entry = await buildCustomChainEntry(details)
+    if (!entry) {
         console.log(
             '\x1b[33m%s\x1b[0m',
-            'Chain with same Short-Name already exists in your settings activated chain list'
+            'Could not build a custom chain entry. Check name, chainId, and ensure a customChain{N} slot is free.'
         )
-    else if (ActivatedChainList.find((chain: IChain) => chain.chainId === chainDetails.chainId))
-        console.log('\x1b[33m%s\x1b[0m', 'Chain with same chainId already exists in your settings activated chain list')
-    else await addChain(chainDetails.chainName, chainDetails)
+        return false
+    }
+
+    const FullChainList = DefaultChainList
+    const ActivatedChainList = await buildActivatedChainList()
+    if (FullChainList.find((chain: IChain) => chain.chainName === entry.chainName)) {
+        console.log('\x1b[33m%s\x1b[0m', CHAIN_CONFLICT_MESSAGES.defaultShortName)
+        return false
+    }
+    if (FullChainList.find((chain: IChain) => chain.chainId === entry.chainId)) {
+        console.log('\x1b[33m%s\x1b[0m', CHAIN_CONFLICT_MESSAGES.defaultChainId)
+        return false
+    }
+    if (ActivatedChainList.find((chain: IChain) => chain.chainName === entry.chainName)) {
+        console.log('\x1b[33m%s\x1b[0m', CHAIN_CONFLICT_MESSAGES.activatedShortName)
+        return false
+    }
+    if (ActivatedChainList.find((chain: IChain) => chain.chainId === entry.chainId)) {
+        console.log('\x1b[33m%s\x1b[0m', CHAIN_CONFLICT_MESSAGES.activatedChainId)
+        return false
+    }
+
+    await addChain(entry.chainName, entry)
+    return true
+}
+
+/**
+ * Render the value consumed by `--addCustomChain` so the printed CLI command
+ * round-trips through {@link parseAddCustomChainFlag}.
+ *
+ * The flag value is a JSON object with the user-visible fields (`name`,
+ * `chainId`, optional `gas`, optional `defaultRpcUrl`). JSON is the only
+ * delimiter that survives every realistic payload (commas in names, colons
+ * in RPC URLs, …) and matches the convention `--addCustomCommand` already
+ * uses for structured settings entries.
+ */
+export const formatAddCustomChainFlag = (details: IAddCustomChainInput): string =>
+    JSON.stringify({
+        name: details.name,
+        chainId: details.chainId,
+        gas: details.gas,
+        defaultRpcUrl: details.defaultRpcUrl
+    })
+
+/**
+ * Parse the `--addCustomChain` CLI flag value.
+ *
+ * Returns `undefined` for anything that is not a valid JSON object with the
+ * required `name` / `chainId` fields so `serveCli` can warn the user instead
+ * of silently adding a malformed entry. The chainId coercion handles the
+ * `1234` vs `"1234"` ambiguity (JSON numbers are parsed as numbers; JSON
+ * strings of digits are coerced via `Number()`).
+ */
+export const parseAddCustomChainFlag = (value: string | undefined): IAddCustomChainInput | undefined => {
+    if (typeof value !== 'string' || value.trim() === '') return undefined
+    let parsed: any
+    try {
+        parsed = JSON.parse(value)
+    } catch {
+        return undefined
+    }
+    if (!parsed || typeof parsed !== 'object') return undefined
+    const name = typeof parsed.name === 'string' ? parsed.name.trim() : ''
+    if (!name) return undefined
+    const rawChainId = typeof parsed.chainId === 'number' ? parsed.chainId : Number(parsed.chainId)
+    if (!Number.isFinite(rawChainId) || !Number.isInteger(rawChainId) || rawChainId <= 0) return undefined
+    const input: IAddCustomChainInput = { name, chainId: rawChainId }
+    if (typeof parsed.gas === 'string' && parsed.gas.trim() !== '') input.gas = parsed.gas.trim()
+    if (typeof parsed.defaultRpcUrl === 'string' && parsed.defaultRpcUrl.trim() !== '')
+        input.defaultRpcUrl = parsed.defaultRpcUrl.trim()
+    return input
 }
 
 /**

--- a/src/serveInquirer.ts
+++ b/src/serveInquirer.ts
@@ -29,10 +29,12 @@ import {
 import buildMockContract, { buildMockDeploymentScriptOrTest } from './buildMockContracts.ts'
 import {
     addActivatedChain,
-    addCustomChain,
     buildActivatedChainNetworkConfig,
     buildNetworkSelectorChoices,
-    removeActivatedChain
+    formatAddCustomChainFlag,
+    parseAddCustomChainFlag,
+    removeActivatedChain,
+    runAddCustomChain
 } from './buildNetworks.ts'
 import {
     formatVerifyContractFlag,
@@ -429,36 +431,18 @@ const serveSettingSelector = async (env: IHreContext) => {
                 message: 'Chain default RPC Url'
             }
         ])
-        const getNetworkConfig = buildActivatedChainNetworkConfig()
-        let buildNetworkConfig: { networks: Record<string, unknown>[] } = { networks: [{}] }
-        if (getNetworkConfig) {
-            buildNetworkConfig = JSON.parse(
-                `{
-                    "networks": [
-                        {${getNetworkConfig}}
-                    ]
-                }`
-            )
-        }
-        let chainName: string = ''
-        const firstNetwork = buildNetworkConfig.networks[0]
-        for (let i = 1; i <= 8; i++) {
-            const key = `customChain${i}`
-            if (firstNetwork[key] !== undefined && !chainName) {
-                chainName = key
-                break
-            }
-        }
-        if (chainName) {
-            const chainToAdd: IChain = {
-                name: chainSelected.name,
-                chainName,
-                chainId: chainSelected.chainId,
-                gas: chainSelected.gas,
-                defaultRpcUrl: chainSelected.defaultRpcUrl
-            }
-            await addCustomChain(chainToAdd)
-        }
+        // inquirer `input` returns strings even for numeric fields, so coerce
+        // chainId to a number before handing off to the shared runner that
+        // backs the `--addCustomChain` CLI flag. The runner picks the next
+        // free `customChain{N}` slot and prints the same conflict warnings as
+        // the menu flow used to.
+        const parsedChainId = Number(chainSelected.chainId)
+        await runAddCustomChain({
+            name: chainSelected.name,
+            chainId: parsedChainId,
+            gas: chainSelected.gas,
+            defaultRpcUrl: chainSelected.defaultRpcUrl
+        })
     }
     if (settingSelected.settings === 'See all config for activated chain') {
         const getNetworkConfig = buildActivatedChainNetworkConfig()
@@ -1256,6 +1240,7 @@ interface ICliArgs {
     addFoundry?: string
     addFoundryTestUtility?: string
     addActivatedChain?: string
+    addCustomChain?: string
     removeActivatedChain?: string
     getAccountBalance?: string
     addCustomMockContract?: string
@@ -1390,6 +1375,19 @@ const serveCli = async (args: ICliArgs, env: IHreContext) => {
             return installFoundryTestUtility()
         case isPresentString(args.addActivatedChain):
             return addActivatedChain(args.addActivatedChain)
+        case isPresentString(args.addCustomChain): {
+            const parsed = parseAddCustomChainFlag(args.addCustomChain)
+            if (!parsed) {
+                console.log(
+                    '\x1b[33m%s\x1b[0m',
+                    'Invalid --addCustomChain value. Expected a JSON object with at least "name" (string) and "chainId" (positive integer).'
+                )
+                return
+            }
+            const added = await runAddCustomChain(parsed)
+            if (added) displayFinalCliCommand('addCustomChain', formatAddCustomChainFlag(parsed))
+            return
+        }
         case isPresentString(args.removeActivatedChain):
             return removeActivatedChain(args.removeActivatedChain)
         case isAffirmativeString(args.getAccountBalance):

--- a/test/buildCustomCommands.test.ts
+++ b/test/buildCustomCommands.test.ts
@@ -261,6 +261,12 @@ describe('buildCustomCommands (issue #172)', function () {
             // project — perfect for a smoke test that the spawn path is
             // wired up correctly. Skip on platforms where `npx` is not
             // available (CI images almost always have it).
+            //
+            // Cold-start `npx hardhat --version` walks npm to resolve the
+            // package and then loads Hardhat — easily 5–10 s on a fresh CI
+            // runner with no warm npx cache. Bump the per-test timeout well
+            // above the 6 s project default so this smoke test stays reliable.
+            this.timeout(30000)
             const entry: ICustomCommand = { name: 'hh-version', kind: 'hardhat', command: '--version' }
             await runCustomCommand(entry)
             // If we got here without throwing, the child exited cleanly.

--- a/test/buildNetworks.test.ts
+++ b/test/buildNetworks.test.ts
@@ -3,7 +3,15 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 
-import { buildActivatedChainNetworkConfig, buildNetworkSelectorChoices } from '../src/buildNetworks.ts'
+import {
+    buildActivatedChainNetworkConfig,
+    buildCustomChainEntry,
+    buildNetworkSelectorChoices,
+    findAvailableCustomChainSlot,
+    formatAddCustomChainFlag,
+    parseAddCustomChainFlag,
+    runAddCustomChain
+} from '../src/buildNetworks.ts'
 import { DefaultChainList } from '../src/config.ts'
 import type { IChain } from '../src/types.ts'
 
@@ -114,5 +122,289 @@ describe('buildActivatedChainNetworkConfig (secrets redaction)', function () {
         const config = buildActivatedChainNetworkConfig()
         expect(config).to.be.a('string')
         expect(config).to.not.match(/\b0x[0-9a-fA-F]{8}/)
+    })
+})
+
+/**
+ * Tests for the `--addCustomChain` helper (issue #165).
+ *
+ * Mirrors the structure of the other build* suites: each case runs in a
+ * fresh temp directory so the `hardhat-awesome-cli.json` written by
+ * `runAddCustomChain` cannot leak into a sibling test.
+ */
+describe('addCustomChain helpers (issue #165)', function () {
+    const originalCwd = process.cwd()
+    let fixtureDirectory: string
+
+    beforeEach(function () {
+        fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-add-custom-chain-'))
+        process.chdir(fixtureDirectory)
+    })
+
+    afterEach(function () {
+        process.chdir(originalCwd)
+        fs.rmSync(fixtureDirectory, { recursive: true, force: true })
+    })
+
+    describe('findAvailableCustomChainSlot', function () {
+        it('Returns customChain1 when no settings file exists', async function () {
+            expect(await findAvailableCustomChainSlot()).to.equal('customChain1')
+        })
+
+        it('Returns the first free slot when some are already taken', async function () {
+            fs.writeFileSync(
+                'hardhat-awesome-cli.json',
+                JSON.stringify({
+                    activatedChain: [
+                        { name: 'First', chainName: 'customChain1', chainId: 9001, gas: 'auto' },
+                        { name: 'Second', chainName: 'customChain2', chainId: 9002, gas: 'auto' }
+                    ]
+                })
+            )
+            expect(await findAvailableCustomChainSlot()).to.equal('customChain3')
+        })
+
+        it('Returns undefined when every customChain{N} slot (1..8) is taken', async function () {
+            const slots = Array.from({ length: 8 }, (_, i) => i + 1).map((n) => ({
+                name: `Slot ${n}`,
+                chainName: `customChain${n}`,
+                chainId: 9100 + n,
+                gas: 'auto'
+            }))
+            fs.writeFileSync('hardhat-awesome-cli.json', JSON.stringify({ activatedChain: slots }))
+            expect(await findAvailableCustomChainSlot()).to.equal(undefined)
+        })
+    })
+
+    describe('buildCustomChainEntry', function () {
+        it('Returns a fully-populated IChain with the first free slot', async function () {
+            const entry = await buildCustomChainEntry({
+                name: 'My Custom',
+                chainId: 12345,
+                gas: '120000000',
+                defaultRpcUrl: 'https://rpc.example.invalid'
+            })
+            expect(entry).to.deep.equal({
+                name: 'My Custom',
+                chainName: 'customChain1',
+                chainId: 12345,
+                gas: '120000000',
+                defaultRpcUrl: 'https://rpc.example.invalid'
+            })
+        })
+
+        it('Defaults gas to "auto" and omits defaultRpcUrl when missing', async function () {
+            const entry = await buildCustomChainEntry({ name: 'Minimal', chainId: 42 })
+            expect(entry).to.deep.equal({
+                name: 'Minimal',
+                chainName: 'customChain1',
+                chainId: 42,
+                gas: 'auto'
+            })
+            expect(entry).to.not.have.property('defaultRpcUrl')
+        })
+
+        it('Trims whitespace around name, gas, and defaultRpcUrl', async function () {
+            const entry = await buildCustomChainEntry({
+                name: '  Trimmed  ',
+                chainId: 7,
+                gas: '  auto  ',
+                defaultRpcUrl: '  https://rpc.example.invalid  '
+            })
+            expect(entry?.name).to.equal('Trimmed')
+            expect(entry?.gas).to.equal('auto')
+            expect(entry?.defaultRpcUrl).to.equal('https://rpc.example.invalid')
+        })
+
+        it('Coerces a numeric string chainId to a number', async function () {
+            const entry = await buildCustomChainEntry({ name: 'Coerced', chainId: '314' as unknown as number })
+            expect(entry?.chainId).to.equal(314)
+        })
+
+        it('Returns undefined when name is missing or empty', async function () {
+            expect(await buildCustomChainEntry({ name: '', chainId: 1 })).to.equal(undefined)
+            expect(await buildCustomChainEntry({ name: '   ', chainId: 1 })).to.equal(undefined)
+        })
+
+        it('Returns undefined when chainId is missing, zero, or negative', async function () {
+            expect(await buildCustomChainEntry({ name: 'x', chainId: 0 })).to.equal(undefined)
+            expect(await buildCustomChainEntry({ name: 'x', chainId: -1 })).to.equal(undefined)
+            expect(await buildCustomChainEntry({ name: 'x' } as any)).to.equal(undefined)
+            expect(await buildCustomChainEntry({ name: 'x', chainId: 'abc' as unknown as number })).to.equal(undefined)
+            expect(await buildCustomChainEntry({ name: 'x', chainId: 1.5 as unknown as number })).to.equal(undefined)
+        })
+
+        it('Returns undefined when no customChain{N} slot is free', async function () {
+            const slots = Array.from({ length: 8 }, (_, i) => i + 1).map((n) => ({
+                name: `Slot ${n}`,
+                chainName: `customChain${n}`,
+                chainId: 9200 + n,
+                gas: 'auto'
+            }))
+            fs.writeFileSync('hardhat-awesome-cli.json', JSON.stringify({ activatedChain: slots }))
+            expect(await buildCustomChainEntry({ name: 'Overflow', chainId: 9999 })).to.equal(undefined)
+        })
+    })
+
+    describe('runAddCustomChain', function () {
+        it('Persists a new chain on a fresh project and reports success', async function () {
+            const added = await runAddCustomChain({
+                name: 'My Custom',
+                chainId: 7777,
+                gas: 'auto',
+                defaultRpcUrl: 'https://rpc.example.invalid'
+            })
+
+            expect(added).to.equal(true)
+            const onDisk = JSON.parse(fs.readFileSync('hardhat-awesome-cli.json', 'utf8'))
+            expect(onDisk.activatedChain).to.deep.equal([
+                {
+                    name: 'My Custom',
+                    chainName: 'customChain1',
+                    chainId: 7777,
+                    gas: 'auto',
+                    defaultRpcUrl: 'https://rpc.example.invalid'
+                }
+            ])
+        })
+
+        it('Picks the next free slot when some are already taken', async function () {
+            fs.writeFileSync(
+                'hardhat-awesome-cli.json',
+                JSON.stringify({
+                    activatedChain: [
+                        { name: 'First', chainName: 'customChain1', chainId: 9001, gas: 'auto' }
+                    ]
+                })
+            )
+
+            const added = await runAddCustomChain({ name: 'Second', chainId: 9002 })
+
+            expect(added).to.equal(true)
+            const onDisk = JSON.parse(fs.readFileSync('hardhat-awesome-cli.json', 'utf8'))
+            const customEntry = onDisk.activatedChain.find((chain: IChain) => chain.name === 'Second')
+            expect(customEntry.chainName).to.equal('customChain2')
+        })
+
+        it('Returns false and writes nothing when the chainId collides with a default chain', async function () {
+            // `ethereum` defaults to chainId 1 in DefaultChainList. Use a
+            // random free short name slot so the slot-picker alone does not
+            // mask the chainId conflict.
+            const added = await runAddCustomChain({ name: 'Ethereum clone', chainId: 1 })
+
+            expect(added).to.equal(false)
+            expect(fs.existsSync('hardhat-awesome-cli.json')).to.equal(false)
+        })
+
+        it('Returns false and writes nothing when the chainId collides with an existing activated chain', async function () {
+            fs.writeFileSync(
+                'hardhat-awesome-cli.json',
+                JSON.stringify({
+                    activatedChain: [
+                        { name: 'Existing', chainName: 'customChain1', chainId: 5050, gas: 'auto' }
+                    ]
+                })
+            )
+
+            const added = await runAddCustomChain({ name: 'Clash', chainId: 5050 })
+
+            expect(added).to.equal(false)
+            const onDisk = JSON.parse(fs.readFileSync('hardhat-awesome-cli.json', 'utf8'))
+            expect(onDisk.activatedChain).to.have.lengthOf(1)
+            expect(onDisk.activatedChain[0].name).to.equal('Existing')
+        })
+
+        it('Returns false when every customChain{N} slot is taken', async function () {
+            const slots = Array.from({ length: 8 }, (_, i) => i + 1).map((n) => ({
+                name: `Slot ${n}`,
+                chainName: `customChain${n}`,
+                chainId: 9300 + n,
+                gas: 'auto'
+            }))
+            fs.writeFileSync('hardhat-awesome-cli.json', JSON.stringify({ activatedChain: slots }))
+
+            const added = await runAddCustomChain({ name: 'Overflow', chainId: 9999 })
+
+            expect(added).to.equal(false)
+        })
+
+        it('Returns false on invalid input without touching the settings file', async function () {
+            fs.writeFileSync(
+                'hardhat-awesome-cli.json',
+                JSON.stringify({
+                    activatedChain: [
+                        { name: 'Untouched', chainName: 'customChain1', chainId: 1, gas: 'auto' }
+                    ]
+                })
+            )
+
+            expect(await runAddCustomChain({ name: '', chainId: 1 })).to.equal(false)
+            expect(await runAddCustomChain({ name: 'bad', chainId: -1 })).to.equal(false)
+
+            const onDisk = JSON.parse(fs.readFileSync('hardhat-awesome-cli.json', 'utf8'))
+            expect(onDisk.activatedChain).to.have.lengthOf(1)
+            expect(onDisk.activatedChain[0].name).to.equal('Untouched')
+        })
+    })
+
+    describe('formatAddCustomChainFlag / parseAddCustomChainFlag', function () {
+        it('Round-trips a fully-specified payload', function () {
+            const input = {
+                name: 'My Custom',
+                chainId: 7777,
+                gas: 'auto',
+                defaultRpcUrl: 'https://rpc.example.invalid'
+            }
+            const formatted = formatAddCustomChainFlag(input)
+            const parsed = parseAddCustomChainFlag(formatted)
+            expect(parsed).to.deep.equal(input)
+        })
+
+        it('Round-trips the minimal payload (only name + chainId)', function () {
+            const formatted = formatAddCustomChainFlag({ name: 'Minimal', chainId: 42 })
+            const parsed = parseAddCustomChainFlag(formatted)
+            expect(parsed).to.deep.equal({ name: 'Minimal', chainId: 42 })
+        })
+
+        it('Returns undefined for an empty or missing flag value', function () {
+            expect(parseAddCustomChainFlag(undefined)).to.equal(undefined)
+            expect(parseAddCustomChainFlag('')).to.equal(undefined)
+            expect(parseAddCustomChainFlag('   ')).to.equal(undefined)
+        })
+
+        it('Returns undefined for malformed JSON', function () {
+            expect(parseAddCustomChainFlag('not json')).to.equal(undefined)
+            expect(parseAddCustomChainFlag('{"name":')).to.equal(undefined)
+        })
+
+        it('Returns undefined for a JSON value that is not an object', function () {
+            expect(parseAddCustomChainFlag('null')).to.equal(undefined)
+            expect(parseAddCustomChainFlag('"a string"')).to.equal(undefined)
+            expect(parseAddCustomChainFlag('123')).to.equal(undefined)
+        })
+
+        it('Returns undefined when name is missing or empty', function () {
+            expect(parseAddCustomChainFlag('{"chainId":1}')).to.equal(undefined)
+            expect(parseAddCustomChainFlag('{"name":"","chainId":1}')).to.equal(undefined)
+            expect(parseAddCustomChainFlag('{"name":"   ","chainId":1}')).to.equal(undefined)
+        })
+
+        it('Returns undefined when chainId is missing, zero, or negative', function () {
+            expect(parseAddCustomChainFlag('{"name":"x"}')).to.equal(undefined)
+            expect(parseAddCustomChainFlag('{"name":"x","chainId":0}')).to.equal(undefined)
+            expect(parseAddCustomChainFlag('{"name":"x","chainId":-5}')).to.equal(undefined)
+            expect(parseAddCustomChainFlag('{"name":"x","chainId":"abc"}')).to.equal(undefined)
+        })
+
+        it('Coerces a numeric string chainId to a number on the way in', function () {
+            expect(parseAddCustomChainFlag('{"name":"x","chainId":"314"}')?.chainId).to.equal(314)
+        })
+
+        it('Drops blank gas / defaultRpcUrl on the way in', function () {
+            expect(parseAddCustomChainFlag('{"name":"x","chainId":1,"gas":"  ","defaultRpcUrl":""}')).to.deep.equal({
+                name: 'x',
+                chainId: 1
+            })
+        })
     })
 })


### PR DESCRIPTION
## Summary

Exposes the "Add a custom chain to the current chain selection" sub-flow as a `--addCustomChain` CLI flag (issue #165).

The flag value is a JSON object with the user-visible fields (`name`, `chainId`, optional `gas`, optional `defaultRpcUrl`). The internal `customChain{N}` slot (`customChain1`..`customChain8`) is assigned automatically by `runAddCustomChain` so the menu and the CLI surface stay in lock-step.

## Changes

- **`src/buildNetworks.ts`** — adds `IAddCustomChainInput`, `findAvailableCustomChainSlot`, `buildCustomChainEntry`, `runAddCustomChain`, `formatAddCustomChainFlag`, and `parseAddCustomChainFlag`. `runAddCustomChain` returns `false` (and prints the same yellow warnings as the menu) on every failure mode: invalid payload, no free slot, default chain collision, activated chain collision.
- **`src/serveInquirer.ts`** — replaces the inline custom-chain form with a delegation to `runAddCustomChain`, adds `addCustomChain?` to `ICliArgs`, and wires the flag into `serveCli`. The interactive sub-flow now picks the first free slot instead of the previous (broken) "first already-used" lookup.
- **`test/buildNetworks.test.ts`** — 25 new tests covering slot picking, entry building (defaults, trimming, coercion, validation), the full write path (success + every failure mode), and the flag helpers' round-trip.
- **`README.md`** — adds an `Add a custom chain flag` section mirroring the `Flatten contracts flag` section, and a one-liner in the `## CLI optional flags` list.
- **`.changeset/add-custom-chain.md`** — minor changeset entry closing #165.

## Example

```bash
# Minimal payload — name + chainId, gas defaults to "auto"
npx hardhat cli --addCustomChain '{"name":"My Chain","chainId":7777}'

# Fully-specified payload
npx hardhat cli --addCustomChain '{"name":"My Chain","chainId":7777,"gas":"auto","defaultRpcUrl":"https://rpc.example.invalid"}'
```

## Verification

- `npm run lint` — passes (no eslint warnings)
- `npm test` — 313 passing (288 existing + 25 new)
- `npm run smoke` — passes
- `npx tsc --project tsconfig.prod.json --noEmit` — clean