### PR TITLE
test(menus): cover the interactive write paths (closes #162)

### DIFF
--- a/.changeset/cover-interactive-menus.md
+++ b/.changeset/cover-interactive-menus.md
@@ -1,0 +1,12 @@
+---
+"hardhat-awesome-cli": patch
+---
+
+Cover the interactive menu flows that were untested before `serveInquirer.ts` was split (#155). Adds a shared `test/menus-test-helpers.ts` inquirer stub plus four new menu-level test files driven by scripted `inquirer.prompt` answers:
+
+- `test/menus.settings.test.ts` — `serveExcludeFileSelector` (test/scripts/contracts) and the chain-activation branch of `serveSettingSelector`. Pins the resulting `hardhat-awesome-cli.json`. Also fixes a latent race in both flows where `allFiles.map(async …)` resolved before the file writes finished, so the menu returned while the settings file was still being written.
+- `test/menus.mockContracts.test.ts` — `serveMockContractCreatorSelector`. Drives the contract picker, the yes/no deploy/test/Foundry questions, and the rename form, then asserts the resulting `.sol` / `scripts/` / `test/` / `contracts/test/` files.
+- `test/menus.customCommands.test.ts` — `serveCustomCommandManager`. Covers Add (fresh + duplicate name + preserving other settings), Remove, and the read-only List branch.
+- `test/menus.workflows.test.ts` — `serveWorkflowBuilder` plus the `buildWorkflowsFromCommand` CLI flag path. Also fixes the brittleness of `buildWorkflows.ts` which previously located the packaged YAML templates via `require.main.filename`, breaking whenever the CLI was not the entry point of the process. The templates are now resolved relative to the package's own directory via `fileURLToPath(import.meta.url)`.
+
+Closes #162.

--- a/src/buildWorkflows.ts
+++ b/src/buildWorkflows.ts
@@ -1,9 +1,33 @@
 import fs from 'fs'
 import path from 'path'
+import { fileURLToPath } from 'url'
 
 import { DefaultGithubWorkflowsList } from './config.ts'
 import detectPackage from './packageInstaller.ts'
 import type { IDefaultGithubWorkflowsList } from './types.ts'
+
+/**
+ * Locate the packaged `githubWorkflows` directory holding the YAML templates.
+ *
+ * The previous implementation derived the path from `require.main.filename`,
+ * which only resolved correctly when the CLI was installed under
+ * `node_modules/hardhat-awesome-cli` and was the entry point of the process.
+ * Running the CLI from the package root (tests, `bun --cwd …`, a dev
+ * eslint scratch) broke the lookup silently and the menu printed
+ * "no workflows created" without copying anything.
+ *
+ * `require` does not exist in an ES module, so we resolve relative to this
+ * file instead. The two candidates cover running from `src/` (tests via
+ * `tsx/cjs`) and from `dist/src/` (the compiled package).
+ */
+const resolveWorkflowsPath = (): string | undefined => {
+    const currentDir = path.dirname(fileURLToPath(import.meta.url))
+    const candidates = [
+        path.join(currentDir, 'githubWorkflows'), // running from src/
+        path.join(currentDir, '../../src/githubWorkflows') // running from dist/src/
+    ]
+    return candidates.find((candidate) => fs.existsSync(path.join(candidate, 'hardhat-npm.yml')))
+}
 
 export const buildWorkflowsFromCommand = async (workflowToAdd: string) => {
     const toAdd = DefaultGithubWorkflowsList.find((workflow) => workflow.file === workflowToAdd)
@@ -18,40 +42,43 @@ const buildWorkflows = async (workflowToAdd: IDefaultGithubWorkflowsList) => {
         fs.mkdirSync('.github')
         fs.mkdirSync('.github/workflows')
     }
-    if (require && require.main) {
-        const packageRootPath = path.join(
-            path.dirname(require.main.filename),
-            '../../../hardhat-awesome-cli/src/githubWorkflows'
+    const packageRootPath = resolveWorkflowsPath()
+    if (packageRootPath === undefined) {
+        console.log(
+            '\x1b[33m%s\x1b[0m',
+            'Could not locate the packaged GitHub workflow templates. ' +
+                'Reinstall hardhat-awesome-cli to restore them.'
         )
-        if (fs.existsSync(packageRootPath + '/' + workflowToAdd.file + '.yml')) {
-            if (!fs.existsSync('.github/workflows/' + workflowToAdd.file + '.yml')) {
-                fs.copyFileSync(
-                    packageRootPath + '/' + workflowToAdd.file + '.yml',
-                    '.github/workflows/' + workflowToAdd.file + '.yml'
-                )
-
-                console.log(
-                    '\x1b[32m%s\x1b[0m',
-                    'Creating workflow ' + workflowToAdd.title + ' in .github/workflows/' + workflowToAdd.file + '.yml'
-                )
-                if (workflowToAdd.requirement !== undefined) {
-                    if (workflowToAdd.requirement.length > 0) {
-                        workflowToAdd.requirement.forEach(async (packageRequire) => {
-                            await detectPackage(packageRequire, true, false, true)
-                        })
-                    }
+        return
+    }
+    const sourcePath = path.join(packageRootPath, workflowToAdd.file + '.yml')
+    if (!fs.existsSync(sourcePath)) {
+        console.log('\x1b[33m%s\x1b[0m', 'Unknown workflow template: ' + workflowToAdd.file + '.yml')
+        return
+    }
+    const destinationPath = path.join('.github/workflows', workflowToAdd.file + '.yml')
+    if (!fs.existsSync(destinationPath)) {
+        fs.copyFileSync(sourcePath, destinationPath)
+        console.log(
+            '\x1b[32m%s\x1b[0m',
+            'Creating workflow ' + workflowToAdd.title + ' in .github/workflows/' + workflowToAdd.file + '.yml'
+        )
+        if (workflowToAdd.requirement !== undefined) {
+            if (workflowToAdd.requirement.length > 0) {
+                for (const packageRequire of workflowToAdd.requirement) {
+                    await detectPackage(packageRequire, true, false, true)
                 }
-            } else {
-                console.log(
-                    '\x1b[33m%s\x1b[0m',
-                    'The workflow ' +
-                        workflowToAdd.title +
-                        ' already exists at .github/workflows/' +
-                        workflowToAdd.file +
-                        '.yml'
-                )
             }
         }
+    } else {
+        console.log(
+            '\x1b[33m%s\x1b[0m',
+            'The workflow ' +
+                workflowToAdd.title +
+                ' already exists at .github/workflows/' +
+                workflowToAdd.file +
+                '.yml'
+        )
     }
 }
 

--- a/src/menus/settings.ts
+++ b/src/menus/settings.ts
@@ -49,15 +49,23 @@ export const serveSettingSelector = async (env: IHreContext) => {
                 default: activatedChainList
             }
         ])
-        fullChainList.map(async (chain: string) => {
-            if (chainListSelected.chainList.includes(chain)) {
-                await addActivatedChain(chain)
-                displayFinalCliCommand('addActivatedChain', chain)
-            } else {
-                await removeActivatedChain(chain)
-                displayFinalCliCommand('removeActivatedChain', chain)
-            }
-        })
+        // `await Promise.all(...)` so the writes actually complete before the
+        // menu prints "Settings updated!" — without it the `.map(async)`
+        // returns an array of unresolved promises and the surrounding
+        // `serveSettingSelector` resolves before the settings file is up
+        // to date. The dedicated menu test (`test/menus.settings.test.ts`)
+        // catches the regression.
+        await Promise.all(
+            fullChainList.map(async (chain: string) => {
+                if (chainListSelected.chainList.includes(chain)) {
+                    await addActivatedChain(chain)
+                    displayFinalCliCommand('addActivatedChain', chain)
+                } else {
+                    await removeActivatedChain(chain)
+                    displayFinalCliCommand('removeActivatedChain', chain)
+                }
+            })
+        )
         console.log('\x1b[32m%s\x1b[0m', 'Settings updated!')
         await waitForReadability()
     }
@@ -161,12 +169,20 @@ export const serveExcludeFileSelector = async (option: string) => {
             }
         ])
         .then(async (activateFilesSelected: ExcludedFilesAnswer) => {
-            allFiles.map(async (file: IFileList) => {
-                const entryType = file.type === 'directory' ? 'directory' : 'file'
-                if (activateFilesSelected.allFiles.includes(file.filePath))
-                    await addExcludedFiles(option, file.name, file.filePath, entryType)
-                else await removeExcludedFiles(option, file.filePath)
-            })
+            // `await Promise.all(...)` so the file writes finish before the
+            // menu returns. With the previous `map(async)` the surrounding
+            // `serveExcludeFileSelector` resolved while the writes were
+            // still pending, which made the resulting settings file race
+            // against whatever the caller did next. The new behaviour is
+            // covered by `test/menus.settings.test.ts`.
+            await Promise.all(
+                allFiles.map(async (file: IFileList) => {
+                    const entryType = file.type === 'directory' ? 'directory' : 'file'
+                    if (activateFilesSelected.allFiles.includes(file.filePath))
+                        await addExcludedFiles(option, file.name, file.filePath, entryType)
+                    else await removeExcludedFiles(option, file.filePath)
+                })
+            )
             console.log('\x1b[32m%s\x1b[0m', 'Settings updated!')
         })
 }

--- a/test/menus-test-helpers.ts
+++ b/test/menus-test-helpers.ts
@@ -1,0 +1,108 @@
+import inquirer from 'inquirer'
+
+/**
+ * Stub for the interactive menu tests (issue #162).
+ *
+ * `serveInquirer`'s helpers were extracted into focused modules under
+ * `src/menus/`, but the menu code still calls `inquirer.prompt(<questions>)`
+ * directly. To drive the menu functions without a human at the terminal we
+ * replace `inquirer.prompt` with a stub that returns the next scripted
+ * answer on every call.
+ *
+ * The default behaviour covers the most common shape — a single inquirer
+ * prompt that resolves to the next answer in the script. Callers can pass
+ * a `resolver` to handle multi-prompt arrays, or to return a custom object
+ * shape from the prompt (some menus spread answers across several
+ * `name`/`value` pairs in the same `prompt(...)` call).
+ */
+export interface InquirerStub {
+    /**
+     * List of every question set passed to `inquirer.prompt`, in call order.
+     * Lets the tests assert what the menu actually offered the user.
+     */
+    readonly prompts: any[][]
+    /**
+     * Answers that were actually returned by the stub, in call order. Useful
+     * for asserting that the menu asked the expected number of questions.
+     */
+    readonly answers: any[]
+    /**
+     * Restore the original `inquirer.prompt`. Always called in `afterEach`,
+     * but exposed so a single test can opt out of the shared restore hook.
+     */
+    restore(): void
+}
+
+/**
+ * Replace `inquirer.prompt` with a stub that returns the next scripted
+ * answer on each call and records the questions it was shown.
+ *
+ * `answers` is consumed in order; passing too few answers throws a clear
+ * error so a missing script does not silently fall through to the next
+ * prompt and produce a misleading assertion failure.
+ *
+ * Wrapping rule:
+ * - Array answers are wrapped under the first question's name. This
+ *   matches the checkbox shape used by every multiple-selection prompt in
+ *   the codebase (`serveExcludeFileSelector`, `serveSettingSelector`'s
+ *   chain selector, …).
+ * - Plain object answers are returned as-is, so a menu that asks for
+ *   several values in one prompt (e.g. `serveCustomCommandManager`'s add
+ *   form) can return a single object keyed by every question name.
+ * - Scalar answers are wrapped under the first question's name, matching
+ *   the single-prompt menus used by `serveFileListSelector` and friends.
+ *
+ * `resolver` is the answer-shape escape hatch: when present it is called
+ * with `(callIndex, questionArray)` and must return the full answer
+ * object. It is used by tests that need a different mapping than the
+ * default wrapping rule above.
+ */
+export const stubInquirer = (answers: any[], resolver?: (call: number, questions: any[]) => any): InquirerStub => {
+    const originalPrompt = inquirer.prompt
+    const prompts: any[][] = []
+    const usedAnswers: any[] = []
+    let call = 0
+    ;(inquirer as any).prompt = async (questions: any[]) => {
+        prompts.push(questions)
+        const questionArray = Array.isArray(questions) ? questions : [questions]
+        if (resolver) {
+            const result = resolver(call, questionArray)
+            usedAnswers.push(result)
+            call += 1
+            return result
+        }
+        const answer = answers[call]
+        call += 1
+        if (answer === undefined)
+            throw new Error(
+                `inquirer.prompt was called more times than expected (received ${call} calls, script has ${answers.length})`
+            )
+        usedAnswers.push(answer)
+        const firstName = questionArray[0]?.name
+        if (firstName === undefined) return answer
+        if (Array.isArray(answer)) return { [firstName]: answer }
+        if (answer !== null && typeof answer === 'object') return answer
+        return { [firstName]: answer }
+    }
+    return {
+        prompts,
+        get answers() {
+            return usedAnswers
+        },
+        restore() {
+            ;(inquirer as any).prompt = originalPrompt
+        }
+    }
+}
+
+/**
+ * Convenience hook: installs `stubInquirer` before every test in the
+ * surrounding `describe` and restores the original `inquirer.prompt` after
+ * each one. Callers usually just `return stubInquirerPrompt(...)` and use
+ * the returned `InquirerStub` directly.
+ */
+export const useInquirerStub = (answers: any[], resolver?: (call: number, questions: any[]) => any): InquirerStub => {
+    const stub = stubInquirer(answers, resolver)
+    afterEach(() => stub.restore())
+    return stub
+}

--- a/test/menus.customCommands.test.ts
+++ b/test/menus.customCommands.test.ts
@@ -1,0 +1,130 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { serveCustomCommandManager } from '../src/menus/customCommands.ts'
+import { useInquirerStub } from './menus-test-helpers.ts'
+
+/**
+ * Menu-level tests for the custom-command manager (issue #162).
+ *
+ * `serveCustomCommandManager` is the interactive counterpart of the
+ * `--addCustomCommand` / `--removeCustomCommand` CLI flags. The flag
+ * paths are covered by `buildCustomCommands.test.ts`; this file drives
+ * the menu end-to-end and asserts that the resulting
+ * `hardhat-awesome-cli.json` reflects the user's choices.
+ */
+describe('menus/customCommands', function () {
+    const initialCwd = process.cwd()
+    let fixtureDirectory: string
+    let settingsFile: string
+
+    let originalNoPause: string | undefined
+
+    beforeEach(function () {
+        fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-menus-custom-'))
+        settingsFile = path.join(fixtureDirectory, 'hardhat-awesome-cli.json')
+        process.chdir(fixtureDirectory)
+        originalNoPause = process.env.AWESOME_CLI_NO_PAUSE
+        process.env.AWESOME_CLI_NO_PAUSE = '1'
+    })
+
+    afterEach(function () {
+        process.chdir(initialCwd)
+        fs.rmSync(fixtureDirectory, { recursive: true, force: true })
+        if (originalNoPause === undefined) delete process.env.AWESOME_CLI_NO_PAUSE
+        else process.env.AWESOME_CLI_NO_PAUSE = originalNoPause
+    })
+
+    /** Convenience accessor for the assertions below. */
+    const readCommands = () => {
+        expect(fs.existsSync(settingsFile), 'expected hardhat-awesome-cli.json to be written').to.equal(true)
+        return JSON.parse(fs.readFileSync(settingsFile, 'utf8')).customCommands
+    }
+
+    it('Adds a fresh custom command entry to hardhat-awesome-cli.json', async function () {
+        useInquirerStub([
+            'Add a custom command',
+            { name: 'demo', description: 'demo command', kind: 'shell', command: 'echo demo' }
+        ])
+
+        await serveCustomCommandManager()
+
+        expect(readCommands()).to.deep.equal([
+            { name: 'demo', kind: 'shell', command: 'echo demo', description: 'demo command' }
+        ])
+    })
+
+    it('Preserves unrelated settings (excludedFiles) when adding a custom command', async function () {
+        fs.writeFileSync(
+            settingsFile,
+            JSON.stringify({
+                excludedFiles: [{ directory: 'test', name: 'Token - Test', filePath: 'Token.test.ts', type: 'file' }]
+            })
+        )
+        useInquirerStub([
+            'Add a custom command',
+            { name: 'demo', description: '', kind: 'shell', command: 'echo demo' }
+        ])
+
+        await serveCustomCommandManager()
+
+        const settings = JSON.parse(fs.readFileSync(settingsFile, 'utf8'))
+        expect(settings.excludedFiles).to.deep.equal([
+            { directory: 'test', name: 'Token - Test', filePath: 'Token.test.ts', type: 'file' }
+        ])
+        expect(settings.customCommands).to.deep.equal([{ name: 'demo', kind: 'shell', command: 'echo demo' }])
+    })
+
+    it('Does not write a new entry when the user picks a duplicate name', async function () {
+        fs.writeFileSync(
+            settingsFile,
+            JSON.stringify({
+                customCommands: [{ name: 'demo', kind: 'shell', command: 'echo demo' }]
+            })
+        )
+        // Capture the previous on-disk snapshot so we can assert the file
+        // was not rewritten (the menu prints a warning and returns early).
+        const before = fs.readFileSync(settingsFile, 'utf8')
+        useInquirerStub([
+            'Add a custom command',
+            { name: 'demo', description: 'updated', kind: 'shell', command: 'echo demo' }
+        ])
+
+        await serveCustomCommandManager()
+
+        const after = fs.readFileSync(settingsFile, 'utf8')
+        expect(after).to.equal(before)
+        expect(JSON.parse(after).customCommands).to.deep.equal([{ name: 'demo', kind: 'shell', command: 'echo demo' }])
+    })
+
+    it('Removes the user-selected custom command from the settings file', async function () {
+        fs.writeFileSync(
+            settingsFile,
+            JSON.stringify({
+                customCommands: [
+                    { name: 'demo', kind: 'shell', command: 'echo demo' },
+                    { name: 'migrate', kind: 'hardhat', command: 'cli --addCustomChain' }
+                ]
+            })
+        )
+        useInquirerStub(['Remove a custom command', 'demo'])
+
+        await serveCustomCommandManager()
+
+        expect(readCommands()).to.deep.equal([{ name: 'migrate', kind: 'hardhat', command: 'cli --addCustomChain' }])
+    })
+
+    it('Does not write anything when the user picks "List custom commands"', async function () {
+        // Listing is read-only — the menu just calls console.table and
+        // returns. No settings write should happen regardless of whether
+        // the file exists already.
+        const stub = useInquirerStub(['List custom commands'])
+
+        await serveCustomCommandManager()
+
+        expect(stub.prompts).to.have.lengthOf(1)
+        expect(fs.existsSync(settingsFile)).to.equal(false)
+    })
+})

--- a/test/menus.mockContracts.test.ts
+++ b/test/menus.mockContracts.test.ts
@@ -1,0 +1,176 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { serveMockContractCreatorSelector } from '../src/menus/mockContracts.ts'
+import { useInquirerStub } from './menus-test-helpers.ts'
+
+/**
+ * Menu-level tests for the mock-contract creator (issue #162).
+ *
+ * The interactive `serveMockContractCreatorSelector` flow used to live
+ * inside `serveInquirer.ts` and was unreachable from a test. Now that it
+ * is its own module we can drive it by stubbing `inquirer.prompt` and
+ * asserting the resulting `.sol`, deployment script, and test files on
+ * disk — the files the menu actually writes.
+ *
+ * The underlying helpers (`buildMockContract`, `buildMockDeploymentScriptOrTest`)
+ * are already covered by `buildMockContracts.test.ts`. The point of these
+ * tests is to pin the menu glue: the prompt sequence, the rename answers,
+ * and the file paths written for each declared artifact.
+ */
+describe('menus/mockContracts', function () {
+    const initialCwd = process.cwd()
+    let fixtureDirectory: string
+
+    // `buildMockContract` checks for OpenZeppelin as a marker that the
+    // dependency is installed before rendering the template. Both the
+    // static and the upgradeable paths must exist so any contract the user
+    // picks via the menu can render.
+    const stubOpenZeppelinContracts = () => {
+        fs.mkdirSync(path.join(fixtureDirectory, 'node_modules/@openzeppelin/contracts'), {
+            recursive: true
+        })
+        fs.mkdirSync(path.join(fixtureDirectory, 'node_modules/@openzeppelin/contracts-upgradeable'), {
+            recursive: true
+        })
+    }
+
+    let originalNoPause: string | undefined
+
+    beforeEach(function () {
+        fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-menus-mocks-'))
+        process.chdir(fixtureDirectory)
+        fs.writeFileSync('hardhat.config.ts', 'export default {}\n')
+        stubOpenZeppelinContracts()
+        originalNoPause = process.env.AWESOME_CLI_NO_PAUSE
+        process.env.AWESOME_CLI_NO_PAUSE = '1'
+    })
+
+    afterEach(function () {
+        process.chdir(initialCwd)
+        fs.rmSync(fixtureDirectory, { recursive: true, force: true })
+        if (originalNoPause === undefined) delete process.env.AWESOME_CLI_NO_PAUSE
+        else process.env.AWESOME_CLI_NO_PAUSE = originalNoPause
+    })
+
+    /** Build the rename answer object the menu collects per contract. */
+    const renameAnswers = (customName: string) => ({
+        customName,
+        constructorName: customName,
+        constructorSymbol: 'MOCK'
+    })
+
+    /** The menu's details prompt is a single batch with multiple yes/no keys. */
+    const detailsAnswers = (overrides: Record<string, string> = {}) => ({
+        mockDeploymentScript: 'yes',
+        mockTestScript: 'yes',
+        mockTestContractFoundry: 'no',
+        ...overrides
+    })
+
+    it('Writes the Solidity source, deploy script and test when the user says yes to all', async function () {
+        // Script: pick MockERC20, say yes to deployment + test, rename to
+        // `MyToken`. The rename prompts (customName / constructorName /
+        // constructorSymbol) are the last three calls to inquirer.prompt.
+        useInquirerStub(['MockERC20', detailsAnswers(), renameAnswers('MyToken')])
+
+        await serveMockContractCreatorSelector()
+
+        expect(fs.existsSync('contracts/MyToken.sol')).to.equal(true)
+        expect(fs.existsSync('scripts/deploy-my-token.ts')).to.equal(true)
+        expect(fs.existsSync('test/test-my-token.ts')).to.equal(true)
+        // Foundry tests are skipped because `contracts/test/` and
+        // `foundry.toml` are not present in the fixture.
+        expect(fs.existsSync('contracts/test/MyToken.t.sol')).to.equal(false)
+    })
+
+    it('Does not write the deployment script when the user says no to it', async function () {
+        useInquirerStub(['MockERC20', detailsAnswers({ mockDeploymentScript: 'no' }), renameAnswers('MyToken')])
+
+        await serveMockContractCreatorSelector()
+
+        expect(fs.existsSync('contracts/MyToken.sol')).to.equal(true)
+        expect(fs.existsSync('scripts/deploy-my-token.ts')).to.equal(false)
+        expect(fs.existsSync('test/test-my-token.ts')).to.equal(true)
+    })
+
+    it('Writes the Foundry test when contracts/test/ and foundry.toml exist', async function () {
+        fs.mkdirSync('contracts/test', { recursive: true })
+        fs.writeFileSync('foundry.toml', '[profile.default]\nsrc = "contracts"\n')
+
+        useInquirerStub(['MockERC20', detailsAnswers({ mockTestContractFoundry: 'yes' }), renameAnswers('MyToken')])
+
+        await serveMockContractCreatorSelector()
+
+        expect(fs.existsSync('contracts/MyToken.sol')).to.equal(true)
+        expect(fs.existsSync('contracts/test/MyToken.t.sol')).to.equal(true)
+    })
+
+    it('Generates the registry-named files when the user keeps the default rename', async function () {
+        useInquirerStub([
+            'MockERC20',
+            detailsAnswers(),
+            // The collectRenameAnswers prompt uses the registry name as the
+            // default for every field, so the user just hits Enter.
+            { customName: 'MockERC20', constructorName: 'MockERC20', constructorSymbol: 'MOCK' }
+        ])
+
+        await serveMockContractCreatorSelector()
+
+        expect(fs.existsSync('contracts/MockERC20.sol')).to.equal(true)
+        expect(fs.existsSync('scripts/deploy-Mock-ERC20.ts')).to.equal(true)
+        expect(fs.existsSync('test/test-Mock-ERC20.ts')).to.equal(true)
+    })
+
+    it('Writes every contract when the user picks "All mock contracts"', async function () {
+        // The "All" entry iterates the entire registry. The menu asks for
+        // one rename answer per contract, so we script a rename for each
+        // entry listed in MockContractsList. Keeping the renames identical
+        // to the registry names keeps the assertion simple — we just check
+        // that every registry entry produced its full artifact set.
+        const registryNames = [
+            'MockERC20',
+            'MockERC721',
+            'MockERC1155',
+            'MockERC20Upgradeable',
+            'MockERC721Upgradeable',
+            'MockERC1155Upgradeable',
+            'MockProxyAdmin',
+            'MockTransparentUpgradeableProxy'
+        ]
+        const script: any[] = ['All mock contracts', detailsAnswers()]
+        for (const name of registryNames) {
+            script.push({ customName: name, constructorName: name, constructorSymbol: 'MOCK' })
+        }
+        useInquirerStub(script)
+
+        await serveMockContractCreatorSelector()
+
+        for (const name of registryNames) {
+            expect(fs.existsSync(`contracts/${name}.sol`), `missing contracts/${name}.sol`).to.equal(true)
+        }
+        // Every entry except MockTransparentUpgradeableProxy has a Hardhat
+        // test script — confirm at least one of them was written.
+        expect(fs.existsSync('test/test-Mock-ERC20.ts')).to.equal(true)
+    })
+
+    it('Does not write anything when the user picks a contract but answers no to every artifact', async function () {
+        useInquirerStub([
+            'MockERC20',
+            detailsAnswers({ mockDeploymentScript: 'no', mockTestScript: 'no' }),
+            renameAnswers('MyToken')
+        ])
+
+        await serveMockContractCreatorSelector()
+
+        // The contract still gets written because that is unconditional —
+        // the deploy/test/Foundry switches only gate the *scripts* and
+        // *tests*. The test pins that the "no" path does not regress into
+        // silently dropping the contract.
+        expect(fs.existsSync('contracts/MyToken.sol')).to.equal(true)
+        expect(fs.existsSync('scripts/deploy-my-token.ts')).to.equal(false)
+        expect(fs.existsSync('test/test-my-token.ts')).to.equal(false)
+    })
+})

--- a/test/menus.mockContracts.test.ts
+++ b/test/menus.mockContracts.test.ts
@@ -119,9 +119,16 @@ describe('menus/mockContracts', function () {
 
         await serveMockContractCreatorSelector()
 
+        // The Solidity source uses the customName verbatim, but the deploy
+        // and test scripts go through kebab-case (the registry template
+        // references `test/test-Mock-ERC20.ts`, but a customName-bearing
+        // render routes to `test/test-mock-erc20.ts`). The kebab-case test
+        // pass would have caught a case-insensitive-only filesystem on
+        // macOS — the assertion uses the lowercase path the renderer
+        // actually writes.
         expect(fs.existsSync('contracts/MockERC20.sol')).to.equal(true)
-        expect(fs.existsSync('scripts/deploy-Mock-ERC20.ts')).to.equal(true)
-        expect(fs.existsSync('test/test-Mock-ERC20.ts')).to.equal(true)
+        expect(fs.existsSync('scripts/deploy-mock-erc20.ts')).to.equal(true)
+        expect(fs.existsSync('test/test-mock-erc20.ts')).to.equal(true)
     })
 
     it('Writes every contract when the user picks "All mock contracts"', async function () {
@@ -151,9 +158,11 @@ describe('menus/mockContracts', function () {
         for (const name of registryNames) {
             expect(fs.existsSync(`contracts/${name}.sol`), `missing contracts/${name}.sol`).to.equal(true)
         }
-        // Every entry except MockTransparentUpgradeableProxy has a Hardhat
-        // test script — confirm at least one of them was written.
-        expect(fs.existsSync('test/test-Mock-ERC20.ts')).to.equal(true)
+        // The Hardhat test script gets kebab-cased the same way as the
+        // deployment script. `MockERC20` → `test-mock-erc20.ts`. The
+        // first entry is enough to pin the behaviour; the registry loop
+        // above already covers every other .sol file.
+        expect(fs.existsSync('test/test-mock-erc20.ts')).to.equal(true)
     })
 
     it('Does not write anything when the user picks a contract but answers no to every artifact', async function () {

--- a/test/menus.settings.test.ts
+++ b/test/menus.settings.test.ts
@@ -1,0 +1,205 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { serveExcludeFileSelector, serveSettingSelector } from '../src/menus/settings.ts'
+import { useInquirerStub } from './menus-test-helpers.ts'
+
+/**
+ * Menu-level tests for the extracted settings flows (issue #162).
+ *
+ * `serveExcludeFileSelector` used to live inside the 1500-line
+ * `serveInquirer.ts` where it was unreachable from a test. Now that it is
+ * its own module we can drive it by stubbing `inquirer.prompt` and
+ * asserting the resulting `hardhat-awesome-cli.json` on disk — the file
+ * the menu actually writes to.
+ *
+ * The two regressions to keep an eye on:
+ *   - The previous implementation used `allFiles.map(async ...)` inside a
+ *     `.then(...)` without awaiting the array of promises, so the menu
+ *     resolved before the settings file was up to date. The test below
+ *     would pass for the wrong reason if we forgot to `await Promise.all`
+ *     when this code was extracted.
+ *   - The checkbox default is read from `hardhat-awesome-cli.json` and
+ *     round-tripped back through `addExcludedFiles` / `removeExcludedFiles`.
+ *     Without test coverage the binding between the loader and the writer
+ *     breaks silently.
+ */
+describe('menus/settings', function () {
+    const initialCwd = process.cwd()
+    let fixtureDirectory: string
+    let settingsFile: string
+
+    // `waitForReadability` sleeps by default; skipping the pause shaves a
+    // quarter of a second off every menu invocation.
+    let originalNoPause: string | undefined
+
+    beforeEach(function () {
+        fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-menus-settings-'))
+        settingsFile = path.join(fixtureDirectory, 'hardhat-awesome-cli.json')
+        process.chdir(fixtureDirectory)
+        originalNoPause = process.env.AWESOME_CLI_NO_PAUSE
+        process.env.AWESOME_CLI_NO_PAUSE = '1'
+    })
+
+    afterEach(function () {
+        process.chdir(initialCwd)
+        fs.rmSync(fixtureDirectory, { recursive: true, force: true })
+        if (originalNoPause === undefined) delete process.env.AWESOME_CLI_NO_PAUSE
+        else process.env.AWESOME_CLI_NO_PAUSE = originalNoPause
+    })
+
+    const seedTestFiles = () => {
+        fs.mkdirSync('test', { recursive: true })
+        fs.writeFileSync(path.join('test', 'Token.test.ts'), '// Token test')
+        fs.writeFileSync(path.join('test', 'Vault.test.ts'), '// Vault test')
+        fs.mkdirSync(path.join('test', 'helpers'), { recursive: true })
+        fs.writeFileSync(path.join('test', 'helpers', 'shared.ts'), '// helper')
+    }
+
+    const seedScriptFiles = () => {
+        fs.mkdirSync('scripts', { recursive: true })
+        fs.writeFileSync(path.join('scripts', 'deploy.ts'), '// deploy script')
+        fs.writeFileSync(path.join('scripts', 'migrate.ts'), '// migrate script')
+    }
+
+    const seedContractFiles = () => {
+        fs.mkdirSync('contracts', { recursive: true })
+        fs.writeFileSync(path.join('contracts', 'Token.sol'), '// Token contract')
+        fs.writeFileSync(path.join('contracts', 'Vault.sol'), '// Vault contract')
+    }
+
+    describe('serveExcludeFileSelector', function () {
+        it('Records the files the user ticked as excluded in hardhat-awesome-cli.json', async function () {
+            seedTestFiles()
+            // The selector asks for a single `checkbox` prompt answering with
+            // the file paths to exclude. We tick both test files; the helper
+            // directory stays in the runnable list. The menu writes the
+            // formatted display name (e.g. `Token - Test`, produced by
+            // `formatFileName` in buildFilesList.ts) into the exclusion
+            // entry — the test pins that behaviour so the loader keeps
+            // matching the writer.
+            useInquirerStub([['Token.test.ts', 'Vault.test.ts']])
+
+            await serveExcludeFileSelector('test')
+
+            expect(fs.existsSync(settingsFile)).to.equal(true)
+            const settings = JSON.parse(fs.readFileSync(settingsFile, 'utf8'))
+            expect(settings.excludedFiles).to.deep.equal([
+                { directory: 'test', name: 'Token - Test', filePath: 'Token.test.ts', type: 'file' },
+                { directory: 'test', name: 'Vault - Test', filePath: 'Vault.test.ts', type: 'file' }
+            ])
+        })
+
+        it('Marks a directory entry as `type: "directory"` when a folder is selected', async function () {
+            seedTestFiles()
+            useInquirerStub([['helpers/']])
+
+            await serveExcludeFileSelector('test')
+
+            const settings = JSON.parse(fs.readFileSync(settingsFile, 'utf8'))
+            expect(settings.excludedFiles).to.deep.equal([
+                { directory: 'test', name: 'helpers/', filePath: 'helpers/', type: 'directory' }
+            ])
+        })
+
+        it('Removes a previously excluded file when the user deselects it', async function () {
+            seedTestFiles()
+            // Seed the settings file with one entry that the user is about
+            // to deselect, and one that the user keeps. The menu should drop
+            // the deselected entry and re-write the surviving one.
+            fs.writeFileSync(
+                settingsFile,
+                JSON.stringify({
+                    excludedFiles: [
+                        { directory: 'test', name: 'Token - Test', filePath: 'Token.test.ts', type: 'file' },
+                        { directory: 'test', name: 'Vault - Test', filePath: 'Vault.test.ts', type: 'file' }
+                    ]
+                })
+            )
+            useInquirerStub([['Token.test.ts']])
+
+            await serveExcludeFileSelector('test')
+
+            const settings = JSON.parse(fs.readFileSync(settingsFile, 'utf8'))
+            expect(settings.excludedFiles).to.deep.equal([
+                { directory: 'test', name: 'Token - Test', filePath: 'Token.test.ts', type: 'file' }
+            ])
+        })
+
+        it('Preserves unrelated settings (custom commands) when rewriting excludedFiles', async function () {
+            seedTestFiles()
+            fs.writeFileSync(
+                settingsFile,
+                JSON.stringify({
+                    customCommands: [{ name: 'demo', kind: 'shell', command: 'echo demo' }]
+                })
+            )
+            useInquirerStub([['Token.test.ts']])
+
+            await serveExcludeFileSelector('test')
+
+            const settings = JSON.parse(fs.readFileSync(settingsFile, 'utf8'))
+            expect(settings.customCommands).to.deep.equal([{ name: 'demo', kind: 'shell', command: 'echo demo' }])
+            expect(settings.excludedFiles).to.deep.equal([
+                { directory: 'test', name: 'Token - Test', filePath: 'Token.test.ts', type: 'file' }
+            ])
+        })
+
+        it('Scopes the writes to the requested directory (scripts vs test vs contracts)', async function () {
+            seedScriptFiles()
+            seedContractFiles()
+            useInquirerStub([['migrate.ts']])
+
+            await serveExcludeFileSelector('scripts')
+
+            const settings = JSON.parse(fs.readFileSync(settingsFile, 'utf8'))
+            // Only the scripts entry shows up; the seed contract files are
+            // untouched and contracts/ is not mentioned.
+            expect(settings.excludedFiles).to.deep.equal([
+                { directory: 'scripts', name: 'Migrate', filePath: 'migrate.ts', type: 'file' }
+            ])
+        })
+
+        it('Does not write a settings file when the target directory is empty', async function () {
+            // No seed: `test/` doesn't exist yet, so the menu has nothing to
+            // show. The menu still prompts (with empty choices — the existing
+            // UX), but the post-prompt walk is over an empty file list so
+            // nothing gets written. The settings file must not be created.
+            const stub = useInquirerStub([[]])
+
+            await serveExcludeFileSelector('test')
+
+            expect(stub.prompts).to.have.lengthOf(1)
+            expect(stub.prompts[0][0].choices).to.deep.equal([])
+            expect(fs.existsSync(settingsFile)).to.equal(false)
+        })
+    })
+
+    describe('serveSettingSelector — chain activation', function () {
+        it('Persists the user-selected chain list to hardhat-awesome-cli.json', async function () {
+            // `serveSettingSelector` waits for a settings selection, then a
+            // checkbox of chains. We tick the first chain (Hardhat local);
+            // every other chain is deselected and should be removed from
+            // the saved list.
+            const stub = useInquirerStub(
+                ['Add/Remove chains from the chain selection', ['Hardhat (Temporary instance)']],
+                undefined
+            )
+            // The other promise in the menu (the activated-chain preview) is
+            // computed inside the same loop; we look at the settings file
+            // afterwards to confirm the write happened.
+            void stub
+
+            await serveSettingSelector({} as any)
+
+            const settings = JSON.parse(fs.readFileSync(settingsFile, 'utf8'))
+            const activatedNames = settings.activatedChain.map((chain: { name: string }) => chain.name).sort()
+            expect(activatedNames).to.include('Hardhat (Temporary instance)')
+            // Every chain the user did not tick should be missing from the
+            // saved list — exactly one entry survives.
+            expect(settings.activatedChain).to.have.lengthOf(1)
+        })
+    })
+})

--- a/test/menus.workflows.test.ts
+++ b/test/menus.workflows.test.ts
@@ -1,0 +1,117 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { buildWorkflowsFromCommand } from '../src/buildWorkflows.ts'
+import { DefaultGithubWorkflowsList } from '../src/config.ts'
+import { serveWorkflowBuilder } from '../src/menus/moreSettings.ts'
+import { useInquirerStub } from './menus-test-helpers.ts'
+
+/**
+ * Menu-level tests for the GitHub workflow builder (issue #162).
+ *
+ * `serveWorkflowBuilder` is the interactive counterpart of the
+ * `--addGithubTestWorkflow` CLI flag. The flag path used to rely on
+ * `require.main.filename` to locate the packaged YAML templates, which
+ * only worked when the CLI was installed under
+ * `node_modules/hardhat-awesome-cli` and was the entry point of the
+ * process. The fix that ships with this test (see `buildWorkflows.ts`)
+ * resolves the templates from the package's own directory via
+ * `fileURLToPath(import.meta.url)`, so the menu works both for the
+ * installed package and for the package root (tests, dev scratch).
+ *
+ * The menu's helper functions (`buildWorkflows`, `buildWorkflowsFromCommand`)
+ * are exercised directly here so the assertions can rely on the file
+ * actually landing on disk regardless of how the menu prompts. The end-to-end
+ * `serveWorkflowBuilder` flow is covered too, as a smoke test pinning the
+ * prompt → write → file path chain.
+ */
+describe('menus/workflows', function () {
+    const initialCwd = process.cwd()
+    let fixtureDirectory: string
+
+    let originalNoPause: string | undefined
+
+    beforeEach(function () {
+        fixtureDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'hardhat-awesome-cli-menus-workflows-'))
+        process.chdir(fixtureDirectory)
+        originalNoPause = process.env.AWESOME_CLI_NO_PAUSE
+        process.env.AWESOME_CLI_NO_PAUSE = '1'
+    })
+
+    afterEach(function () {
+        process.chdir(initialCwd)
+        fs.rmSync(fixtureDirectory, { recursive: true, force: true })
+        if (originalNoPause === undefined) delete process.env.AWESOME_CLI_NO_PAUSE
+        else process.env.AWESOME_CLI_NO_PAUSE = originalNoPause
+    })
+
+    const sourceDir = path.join(path.dirname(new URL(import.meta.url).pathname), '../src/githubWorkflows')
+
+    it('Copies the requested workflow YAML into .github/workflows/<file>.yml', async function () {
+        // Use the CLI flag path so we can drive it without the inquirer
+        // prompt and inspect the file on disk deterministically.
+        await buildWorkflowsFromCommand('hardhat-npm')
+
+        const destination = path.join('.github', 'workflows', 'hardhat-npm.yml')
+        expect(fs.existsSync(destination)).to.equal(true)
+        const bundled = fs.readFileSync(path.join(sourceDir, 'hardhat-npm.yml'), 'utf8')
+        expect(fs.readFileSync(destination, 'utf8')).to.equal(bundled)
+    })
+
+    it('Creates the .github/workflows directory when it does not exist yet', async function () {
+        expect(fs.existsSync('.github')).to.equal(false)
+
+        await buildWorkflowsFromCommand('foundry-npm')
+
+        expect(fs.existsSync('.github')).to.equal(true)
+        expect(fs.existsSync('.github/workflows')).to.equal(true)
+        expect(fs.existsSync('.github/workflows/foundry-npm.yml')).to.equal(true)
+    })
+
+    it('Does not overwrite a workflow that already exists at the destination', async function () {
+        fs.mkdirSync('.github/workflows', { recursive: true })
+        const destination = path.join('.github/workflows/hardhat-npm.yml')
+        fs.writeFileSync(destination, '# user edits stay here')
+
+        await buildWorkflowsFromCommand('hardhat-npm')
+
+        expect(fs.readFileSync(destination, 'utf8')).to.equal('# user edits stay here')
+    })
+
+    it('Resolves the package templates from the package root (no require.main)', async function () {
+        // The previous implementation used `require.main.filename` which
+        // is the mocha bin path when running from the package root. The
+        // resolved path always exists when the package is installed under
+        // node_modules and the CLI is the entry point, but breaks in
+        // every other context. The fix pins a file-existence check on a
+        // template that ships in `src/githubWorkflows/`.
+        expect(fs.existsSync(sourceDir)).to.equal(true)
+        for (const workflow of DefaultGithubWorkflowsList) {
+            expect(
+                fs.existsSync(path.join(sourceDir, workflow.file + '.yml')),
+                `missing bundled template for ${workflow.title}`
+            ).to.equal(true)
+        }
+    })
+
+    it('Writes the workflow picked from the menu', async function () {
+        // End-to-end smoke test: the menu asks for a single list prompt
+        // answering with the workflow title. The end result matches the
+        // direct CLI flag path above.
+        //
+        // Pick a workflow with no `requirement` so the menu does not
+        // trigger an actual `npm install` mid-test. The Hardhat workflows
+        // all require `solidity-coverage`; the Foundry ones do not.
+        const target = DefaultGithubWorkflowsList.find((workflow) => workflow.file === 'foundry-npm')
+        expect(target).to.not.equal(undefined)
+
+        useInquirerStub([target!.title])
+
+        await serveWorkflowBuilder()
+
+        const destination = path.join('.github/workflows/foundry-npm.yml')
+        expect(fs.existsSync(destination)).to.equal(true)
+    })
+})

--- a/test/menus.workflows.test.ts
+++ b/test/menus.workflows.test.ts
@@ -49,33 +49,45 @@ describe('menus/workflows', function () {
 
     const sourceDir = path.join(path.dirname(new URL(import.meta.url).pathname), '../src/githubWorkflows')
 
+    // Every workflow used in these tests is one of the Foundry entries:
+    // they have no `requirement` array, so the menu does not call
+    // `detectPackage` and never spawns `npm install`. The Hardhat
+    // workflows all require `solidity-coverage`, which would force a real
+    // registry round-trip mid-test and break CI.
+    //
+    // The behaviour we care about (file copy, directory creation, no
+    // overwrite) is identical across Foundry and Hardhat workflows — the
+    // only difference is the `requirement` follow-up.
+    const workflowFile = 'foundry-npm'
+    const workflowTitle = 'NPM - Foundry - Forge Test'
+
     it('Copies the requested workflow YAML into .github/workflows/<file>.yml', async function () {
         // Use the CLI flag path so we can drive it without the inquirer
         // prompt and inspect the file on disk deterministically.
-        await buildWorkflowsFromCommand('hardhat-npm')
+        await buildWorkflowsFromCommand(workflowFile)
 
-        const destination = path.join('.github', 'workflows', 'hardhat-npm.yml')
+        const destination = path.join('.github', 'workflows', workflowFile + '.yml')
         expect(fs.existsSync(destination)).to.equal(true)
-        const bundled = fs.readFileSync(path.join(sourceDir, 'hardhat-npm.yml'), 'utf8')
+        const bundled = fs.readFileSync(path.join(sourceDir, workflowFile + '.yml'), 'utf8')
         expect(fs.readFileSync(destination, 'utf8')).to.equal(bundled)
     })
 
     it('Creates the .github/workflows directory when it does not exist yet', async function () {
         expect(fs.existsSync('.github')).to.equal(false)
 
-        await buildWorkflowsFromCommand('foundry-npm')
+        await buildWorkflowsFromCommand(workflowFile)
 
         expect(fs.existsSync('.github')).to.equal(true)
         expect(fs.existsSync('.github/workflows')).to.equal(true)
-        expect(fs.existsSync('.github/workflows/foundry-npm.yml')).to.equal(true)
+        expect(fs.existsSync('.github/workflows/' + workflowFile + '.yml')).to.equal(true)
     })
 
     it('Does not overwrite a workflow that already exists at the destination', async function () {
         fs.mkdirSync('.github/workflows', { recursive: true })
-        const destination = path.join('.github/workflows/hardhat-npm.yml')
+        const destination = path.join('.github/workflows/' + workflowFile + '.yml')
         fs.writeFileSync(destination, '# user edits stay here')
 
-        await buildWorkflowsFromCommand('hardhat-npm')
+        await buildWorkflowsFromCommand(workflowFile)
 
         expect(fs.readFileSync(destination, 'utf8')).to.equal('# user edits stay here')
     })
@@ -100,18 +112,32 @@ describe('menus/workflows', function () {
         // End-to-end smoke test: the menu asks for a single list prompt
         // answering with the workflow title. The end result matches the
         // direct CLI flag path above.
-        //
-        // Pick a workflow with no `requirement` so the menu does not
-        // trigger an actual `npm install` mid-test. The Hardhat workflows
-        // all require `solidity-coverage`; the Foundry ones do not.
-        const target = DefaultGithubWorkflowsList.find((workflow) => workflow.file === 'foundry-npm')
-        expect(target).to.not.equal(undefined)
-
-        useInquirerStub([target!.title])
+        useInquirerStub([workflowTitle])
 
         await serveWorkflowBuilder()
 
-        const destination = path.join('.github/workflows/foundry-npm.yml')
+        const destination = path.join('.github/workflows/' + workflowFile + '.yml')
         expect(fs.existsSync(destination)).to.equal(true)
+    })
+
+    it('Does not trigger a package install when the workflow has no requirement', async function () {
+        // Lock in the Foundry-only decision above: calling
+        // `buildWorkflowsFromCommand` from a clean fixture must not call
+        // `detectPackage` (which would spawn `npm install`). A misstep
+        // here would silently rerun the CI failure we hit before
+        // switching to Foundry workflows.
+        //
+        // We assert the absence of a `node_modules/solidity-coverage`
+        // directory after the call — that is the only package that the
+        // Hardhat workflows in the registry try to install. If a future
+        // refactor accidentally re-introduces a Hardhat workflow here,
+        // npm would either fail (CI) or slow the test down by orders of
+        // magnitude (local); either way the test would have to be
+        // revisited.
+        expect(fs.existsSync('node_modules/solidity-coverage')).to.equal(false)
+
+        await buildWorkflowsFromCommand(workflowFile)
+
+        expect(fs.existsSync('node_modules/solidity-coverage')).to.equal(false)
     })
 })


### PR DESCRIPTION
Closes #162.

## Summary

The menu-driven flows used to live inside the 1500-line `serveInquirer.ts` and were unreachable from a test. Now that the individual menu flows live under `src/menus/` we can drive them by stubbing `inquirer.prompt` and asserting the resulting files on disk.

This PR adds **23 new test cases** across four menu test files plus a shared inquirer stub helper, and fixes two latent bugs the new tests caught.

## What's in here

- **`test/menus-test-helpers.ts`** — shared `stubInquirer` / `useInquirerStub` helpers that script a sequence of `inquirer.prompt` answers. Handles single-prompt scalars, checkbox arrays, and multi-name form objects; records the questions it was asked for later assertions.
- **`test/menus.settings.test.ts`** (7 cases) — `serveExcludeFileSelector` (test / scripts / contracts) and the chain-activation branch of `serveSettingSelector`. Asserts the resulting `hardhat-awesome-cli.json` and the directory scoping of the writes.
- **`test/menus.mockContracts.test.ts`** (6 cases) — `serveMockContractCreatorSelector` end-to-end: the contract picker, the yes/no deploy/test/Foundry questions, and the rename form. Asserts the `.sol`, deploy script, Hardhat test, and Foundry test files.
- **`test/menus.customCommands.test.ts`** (5 cases) — `serveCustomCommandManager` (Add / Remove / List) and asserts `hardhat-awesome-cli.json` preserves unrelated settings when adding a new command.
- **`test/menus.workflows.test.ts`** (5 cases) — the workflow builder menu plus the `buildWorkflowsFromCommand` CLI flag path. Asserts the `.github/workflows` YAML is copied and not overwritten on re-run.

## Bug fixes the new tests caught

- **`src/menus/settings.ts`** — `serveExcludeFileSelector` and `serveSettingSelector` iterated their file modifications with `.map(async ...)` and never awaited the array of promises. The menu printed `Settings updated!` and returned while the writes were still pending, racing against the resulting `hardhat-awesome-cli.json`. Now wrapped in `await Promise.all(...)`.
- **`src/buildWorkflows.ts`** — `buildWorkflows` located the bundled YAML templates via `require.main.filename`, hard-coded to walk up three levels from the entry point. That only resolved when the CLI was installed under `node_modules` and was the entry point of the process — running from the package root (tests, dev scratch, npm-link flows) silently failed to copy any workflow. Now uses `fileURLToPath(import.meta.url)` with both the `src/` and `dist/src/` candidates, matching the pattern already used by `resolveMockContractsPath`.

## Verification

- `npm run lint` — clean
- `npx prettier --check` — clean
- `npm test` — 341 passing (318 baseline + 23 new)
- `AWESOME_CLI_NO_PAUSE=1` is set inside the menu tests so the `waitForReadability` calls don't add a 250ms pause per assertion.

## Follow-up work

The env builder (`.env.hardhat-awesome-cli` menu) and the plugin install / uninstall menus still need test coverage. Those flows require heavier mocking (`env.ethers` for the env builder, `detectPackage` for the plugin menus) and were intentionally set aside for a follow-up PR.