### PR TITLE
fix(deps): remediate Dependabot security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "hardhat-awesome-cli",
-    "version": "0.1.6",
+    "version": "0.7.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "hardhat-awesome-cli",
-            "version": "0.1.6",
+            "version": "0.7.1",
             "license": "MIT",
             "dependencies": {
                 "dotenv": "^17.0.0",
@@ -2700,13 +2700,13 @@
             }
         },
         "node_modules/adm-zip": {
-            "version": "0.4.16",
-            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
-            "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+            "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=0.3.0"
+                "node": ">=14.0"
             }
         },
         "node_modules/ajv": {
@@ -5105,16 +5105,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
-            }
-        },
         "node_modules/read-yaml-file": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
@@ -5260,27 +5250,6 @@
                 "tslib": "^2.1.0"
             }
         },
-        "node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5301,13 +5270,13 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+            "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -74,5 +74,9 @@
     "dependencies": {
         "dotenv": "^17.0.0",
         "inquirer": "^14.0.0"
+    },
+    "overrides": {
+        "adm-zip": "^0.6.0",
+        "serialize-javascript": "^7.0.5"
     }
 }


### PR DESCRIPTION
## Summary
- override `adm-zip` to the patched 0.6.x release for Hardhat
- override `serialize-javascript` to the patched 7.0.x release for Mocha
- regenerate the npm lockfile

Fixes Dependabot alerts #73, #82, and #59.

## Verification
- `npm ci`
- `npm run lint`
- `npm run build`
- `npm run test`
- `npm run test:coverage`
- `npm run smoke`